### PR TITLE
Resolving widthexpand verilator warnings

### DIFF
--- a/core/alu.sv
+++ b/core/alu.sv
@@ -279,7 +279,7 @@ module alu import ariane_pkg::*; #(
                 CLZW, CTZW:  result_o = (lz_tz_wempty) ? 32 : {{riscv::XLEN-5{1'b0}}, lz_tz_wcount};
 
                 // Count population
-                CPOP, CPOPW: result_o = {{(riscv::XLEN-($clog2(riscv::XLEN))){1'b0}}, cpop};
+                CPOP, CPOPW: result_o = {{(riscv::XLEN-($clog2(riscv::XLEN))-1){1'b0}}, cpop};
 
                 // Sign and Zero Extend
                 SEXTB: result_o = {{riscv::XLEN-8{fu_data_i.operand_a[7]}}, fu_data_i.operand_a[7:0]};

--- a/core/alu.sv
+++ b/core/alu.sv
@@ -275,7 +275,7 @@ module alu import ariane_pkg::*; #(
                 BSET, BSETI: result_o = fu_data_i.operand_a | bit_indx;
 
                 // Count Leading/Trailing Zeros
-                CLZ, CTZ  :  result_o = (lz_tz_empty) ? (lz_tz_count + 1) : lz_tz_count;
+                CLZ, CTZ  :  result_o = (lz_tz_empty) ? ({{(riscv::XLEN-$clog2(riscv::XLEN)){1'b0}},lz_tz_count} + 1) : ({{(riscv::XLEN-$clog2(riscv::XLEN)){1'b0}},lz_tz_count});
                 CLZW, CTZW:  result_o = (lz_tz_wempty) ? 32 : {{riscv::XLEN-5{1'b0}}, lz_tz_wcount};
 
                 // Count population
@@ -291,8 +291,8 @@ module alu import ariane_pkg::*; #(
                 ROLW:         result_o = {{riscv::XLEN-32{rolw[31]}}, rolw};
                 ROR, RORI:    result_o = (riscv::XLEN == 64) ? ((fu_data_i.operand_a >> fu_data_i.operand_b[5:0]) | (fu_data_i.operand_a << (riscv::XLEN-fu_data_i.operand_b[5:0]))) : ((fu_data_i.operand_a >> fu_data_i.operand_b[4:0]) | (fu_data_i.operand_a << (riscv::XLEN-fu_data_i.operand_b[4:0])));
                 RORW, RORIW:  result_o = {{riscv::XLEN-32{rorw[31]}}, rorw};
-                ORCB:         result_o = (riscv::XLEN == 64) ? ({{8{|fu_data_i.operand_a[63:56]}}, {8{|fu_data_i.operand_a[55:48]}}, {8{|fu_data_i.operand_a[47:40]}}, {8{|fu_data_i.operand_a[39:32]}}, orcbw}) : orcbw;
-                REV8:         result_o = (riscv::XLEN == 64) ? ({rev8w , {fu_data_i.operand_a[39:32]}, {fu_data_i.operand_a[47:40]}, {fu_data_i.operand_a[55:48]}, {fu_data_i.operand_a[63:56]}}) : rev8w;
+                ORCB:         result_o = (riscv::XLEN == 64) ? ({{8{|fu_data_i.operand_a[63:56]}}, {8{|fu_data_i.operand_a[55:48]}}, {8{|fu_data_i.operand_a[47:40]}}, {8{|fu_data_i.operand_a[39:32]}}, {riscv::XLEN-32{orcbw}}}) : orcbw;
+                REV8:         result_o = (riscv::XLEN == 64) ? ({{riscv::XLEN-32{rev8w}} , {fu_data_i.operand_a[39:32]}, {fu_data_i.operand_a[47:40]}, {fu_data_i.operand_a[55:48]}, {fu_data_i.operand_a[63:56]}}) : rev8w;
 
                 default: ; // default case to suppress unique warning
             endcase

--- a/core/alu.sv
+++ b/core/alu.sv
@@ -291,8 +291,8 @@ module alu import ariane_pkg::*; #(
                 ROLW:         result_o = {{riscv::XLEN-32{rolw[31]}}, rolw};
                 ROR, RORI:    result_o = (riscv::XLEN == 64) ? ((fu_data_i.operand_a >> fu_data_i.operand_b[5:0]) | (fu_data_i.operand_a << (riscv::XLEN-fu_data_i.operand_b[5:0]))) : ((fu_data_i.operand_a >> fu_data_i.operand_b[4:0]) | (fu_data_i.operand_a << (riscv::XLEN-fu_data_i.operand_b[4:0])));
                 RORW, RORIW:  result_o = {{riscv::XLEN-32{rorw[31]}}, rorw};
-                ORCB:         result_o = (riscv::XLEN == 64) ? ({{8{|fu_data_i.operand_a[63:56]}}, {8{|fu_data_i.operand_a[55:48]}}, {8{|fu_data_i.operand_a[47:40]}}, {8{|fu_data_i.operand_a[39:32]}}, {riscv::XLEN-32{orcbw}}}) : orcbw;
-                REV8:         result_o = (riscv::XLEN == 64) ? ({{riscv::XLEN-32{rev8w}} , {fu_data_i.operand_a[39:32]}, {fu_data_i.operand_a[47:40]}, {fu_data_i.operand_a[55:48]}, {fu_data_i.operand_a[63:56]}}) : rev8w;
+                ORCB:         result_o = (riscv::XLEN == 64) ? ({{8{|fu_data_i.operand_a[riscv::XLEN-1:riscv::XLEN-8]}}, {8{|fu_data_i.operand_a[riscv::XLEN-9:riscv::XLEN-16]}}, {8{|fu_data_i.operand_a[riscv::XLEN-17:riscv::XLEN-24]}}, {8{|fu_data_i.operand_a[riscv::XLEN-25:riscv::XLEN-32]}}, {riscv::XLEN-32{orcbw}}}) : orcbw;
+                REV8:         result_o = (riscv::XLEN == 64) ? ({{riscv::XLEN-32{rev8w}} , {fu_data_i.operand_a[riscv::XLEN-25:riscv::XLEN-32]}, {fu_data_i.operand_a[riscv::XLEN-17:riscv::XLEN-24]}, {fu_data_i.operand_a[riscv::XLEN-9:riscv::XLEN-16]}, {fu_data_i.operand_a[riscv::XLEN-1:riscv::XLEN-8]}}) : rev8w;
 
                 default: ; // default case to suppress unique warning
             endcase

--- a/core/ariane_regfile_ff.sv
+++ b/core/ariane_regfile_ff.sv
@@ -52,7 +52,7 @@ module ariane_regfile #(
     always_comb begin : we_decoder
         for (int unsigned j = 0; j < CVA6Cfg.NrCommitPorts; j++) begin
             for (int unsigned i = 0; i < NUM_WORDS; i++) begin
-                if (waddr_i[j] == i)
+                if ({{27{1'b0}},waddr_i[j]} == i)
                     we_dec[j][i] = we_i[j];
                 else
                     we_dec[j][i] = 1'b0;

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -132,8 +132,8 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   if (CVA6Cfg.NOCType == config_pkg::NOC_TYPE_AXI4_ATOP) begin : gen_axi_offset
     // if we generate a noncacheable access, the word will be at offset 0 or 4 in the cl coming from memory
-    assign cl_offset_d = ( dreq_o.ready & dreq_i.req)      ? {dreq_i.vaddr>>2, 2'b0} :
-                         ( paddr_is_nc  & mem_data_req_o ) ? cl_offset_q[2]<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case
+    assign cl_offset_d = ( dreq_o.ready & dreq_i.req)      ? {dreq_i.vaddr[ICACHE_OFFSET_WIDTH-1:2], 2'b0} :
+                         ( paddr_is_nc  & mem_data_req_o ) ? {{ICACHE_OFFSET_WIDTH-1{1'b0}},cl_offset_q[2]}<<2 : // needed since we transfer 32bit over a 64bit AXI bus in this case
                                                              cl_offset_q;
     // request word address instead of cl address in case of NC access
     assign mem_data_o.paddr = (paddr_is_nc) ? {cl_tag_d, vaddr_q[ICACHE_INDEX_WIDTH-1:3], 3'b0} :                                         // align to 64bit

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -124,7 +124,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   // latch this in case we have to stall later on
   // make sure this is 32bit aligned
   assign vaddr_d = (dreq_o.ready & dreq_i.req) ? dreq_i.vaddr : vaddr_q;
-  assign areq_o.fetch_vaddr = {vaddr_q>>2, 2'b0};
+  assign areq_o.fetch_vaddr = {vaddr_q[riscv::VLEN-1:2], 2'b0};
 
   // split virtual address into index and offset to address cache arrays
   assign cl_index    = vaddr_d[ICACHE_INDEX_WIDTH-1:ICACHE_OFFSET_WIDTH];

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -116,7 +116,7 @@ module cva6_icache import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign cl_tag_d  = (areq_i.fetch_valid) ? areq_i.fetch_paddr[ICACHE_TAG_WIDTH+ICACHE_INDEX_WIDTH-1:ICACHE_INDEX_WIDTH] : cl_tag_q;
 
   // noncacheable if request goes to I/O space, or if cache is disabled
-  assign paddr_is_nc = (~cache_en_q) | (~config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{{64-riscv::PLEN}{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
+  assign paddr_is_nc = (~cache_en_q) | (~config_pkg::is_inside_cacheable_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, cl_tag_d, {ICACHE_INDEX_WIDTH{1'b0}}}));
 
   // pass exception through
   assign dreq_o.ex = areq_i.fetch_exception;
@@ -164,7 +164,7 @@ end else begin : gen_piton_offset
 // main control logic
 ///////////////////////////////////////////////////////
   logic addr_ni;
-  assign addr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, areq_i.fetch_paddr);
+  assign addr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}},areq_i.fetch_paddr});
   always_comb begin : p_fsm
     // default assignment
     state_d      = state_q;

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -128,7 +128,7 @@ module wt_axi_adapter import ariane_pkg::*; import wt_cache_pkg::*; #(
   // request side
   always_comb begin : p_axi_req
     // write channel
-    axi_wr_id_in = arb_idx;
+    axi_wr_id_in = {{3{1'b0}},arb_idx};
     axi_wr_data  = {(CVA6Cfg.AxiDataWidth/riscv::XLEN){dcache_data.data}};
     axi_wr_user  = dcache_data.user;
     // Cast to AXI address width

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -131,7 +131,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   logic amo_req_d, amo_req_q;
   logic [63:0] amo_rtrn_mux;
   riscv::xlen_t amo_data;
-  logic [63:0] amo_user; //DCACHE USER ? DATA_USER_WIDTH
+  logic [riscv::XLEN-1:0] amo_user; //DCACHE USER ? DATA_USER_WIDTH
   logic [riscv::PLEN-1:0] tmp_paddr;
   logic [$clog2(NumPorts)-1:0] miss_port_idx;
   logic [DCACHE_CL_IDX_WIDTH-1:0] cnt_d, cnt_q;
@@ -239,9 +239,9 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   always_comb begin
     if (riscv::IS_XLEN64) begin
       if (amo_req_i.size==2'b10) begin
-        amo_data = {amo_req_i.operand_b[0 +: 32], amo_req_i.operand_b[0 +: 32]};
+        amo_data = {amo_req_i.operand_b[0 +: (riscv::XLEN/2)], amo_req_i.operand_b[0 +: (riscv::XLEN/2)]};
       end else begin
-        amo_data = amo_req_i.operand_b;
+        amo_data = amo_req_i.operand_b[riscv::XLEN-1:0];
       end
     end else begin
       amo_data = amo_req_i.operand_b[0 +: 32];

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -278,7 +278,7 @@ module wt_dcache_missunit import ariane_pkg::*; import wt_cache_pkg::*; #(
   assign mem_data_o.way    = (amo_sel) ? '0                  : repl_way;
   assign mem_data_o.data   = (amo_sel) ? amo_data            : miss_wdata_i[miss_port_idx];
   assign mem_data_o.user   = (amo_sel) ? amo_user            : miss_wuser_i[miss_port_idx];
-  assign mem_data_o.size   = (amo_sel) ? amo_req_i.size      : miss_size_i [miss_port_idx];
+  assign mem_data_o.size   = (amo_sel) ? {1'b0,amo_req_i.size}      : miss_size_i [miss_port_idx];
   assign mem_data_o.amo_op = (amo_sel) ? amo_req_i.amo_op    : AMO_NONE;
 
   assign tmp_paddr         = (amo_sel) ? amo_req_i.operand_a[riscv::PLEN-1:0] : miss_paddr_i[miss_port_idx];

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -151,7 +151,7 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
 
   for (genvar k=0; k<DCACHE_MAX_TX;k++) begin : gen_tx_vld
     assign tx_vld_o[k]   = tx_stat_q[k].vld;
-    assign tx_paddr_o[k] = wbuffer_q[tx_stat_q[k].ptr].wtag<<riscv::XLEN_ALIGN_BYTES;
+    assign tx_paddr_o[k] = {{2{1'b0}},wbuffer_q[tx_stat_q[k].ptr].wtag}<<riscv::XLEN_ALIGN_BYTES;
   end
 
 ///////////////////////////////////////////////////////
@@ -186,8 +186,15 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
   // we have to split unaligned data into multiple transfers (see toSize64)
   // e.g. if we have the following valid bytes: 0011_1001 -> TX0: 0000_0001, TX1: 0000_1000, TX2: 0011_0000
 
-  assign miss_size_o = riscv::IS_XLEN64 ? toSize64(bdirty[dirty_ptr]):
-                                          toSize32(bdirty[dirty_ptr]);
+  generate
+      if (riscv::IS_XLEN64) begin
+          assign miss_size_o = {1'b0,toSize64(bdirty[dirty_ptr])};
+      end
+      else begin
+          assign miss_size_o = {1'b0,toSize32(bdirty[dirty_ptr])};
+      end
+  endgenerate
+
 
   // replicate transfers shorter than a dword
   generate
@@ -298,7 +305,7 @@ endgenerate
 
   // trigger TAG readout in cache
   assign rd_tag_only_o = 1'b1;
-  assign rd_paddr   = wbuffer_check_mux.wtag<<riscv::XLEN_ALIGN_BYTES;
+  assign rd_paddr   = {{2{1'b0}},(wbuffer_check_mux.wtag<<riscv::XLEN_ALIGN_BYTES)};
   assign rd_req_o   = |tocheck;
   assign rd_tag_o   = rd_tag_q;//delay by one cycle
   assign rd_idx_o   = rd_paddr[DCACHE_INDEX_WIDTH-1:DCACHE_OFFSET_WIDTH];
@@ -310,7 +317,7 @@ endgenerate
   // if we wrote into a word while it was in-flight, we cannot write the dirty bytes to the cache
   // when the TX returns
   assign wr_data_be_o = tx_stat_q[rtrn_id].be & (~wbuffer_q[rtrn_ptr].dirty);
-  assign wr_paddr     = wbuffer_q[rtrn_ptr].wtag<<riscv::XLEN_ALIGN_BYTES;
+  assign wr_paddr     = {{2{1'b0}},(wbuffer_q[rtrn_ptr].wtag<<riscv::XLEN_ALIGN_BYTES)};
   assign wr_idx_o     = wr_paddr[DCACHE_INDEX_WIDTH-1:DCACHE_OFFSET_WIDTH];
   assign wr_off_o     = wr_paddr[DCACHE_OFFSET_WIDTH-1:0];
   assign wr_data_o    = wbuffer_q[rtrn_ptr].data;
@@ -328,7 +335,7 @@ endgenerate
 
   for (genvar k=0; k<DCACHE_WBUF_DEPTH; k++) begin : gen_flags
     // only for debug, will be pruned
-    assign debug_paddr[k] = wbuffer_q[k].wtag << riscv::XLEN_ALIGN_BYTES;
+    assign debug_paddr[k] = {{2{1'b0}},(wbuffer_q[k].wtag << riscv::XLEN_ALIGN_BYTES)};
 
     // dirty bytes that are ready for transmission.
     // note that we cannot retransmit a word that is already in-flight

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -190,8 +190,15 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
                                           toSize32(bdirty[dirty_ptr]);
 
   // replicate transfers shorter than a dword
-  assign miss_wdata_o = riscv::IS_XLEN64 ? repData64(wbuffer_dirty_mux.data, bdirty_off, miss_size_o[1:0]):
-                                           repData32(wbuffer_dirty_mux.data, bdirty_off, miss_size_o[1:0]);
+  generate
+    if (riscv::IS_XLEN64) begin
+      assign miss_wdata_o = repData64(wbuffer_dirty_mux.data, bdirty_off, miss_size_o[1:0]);
+    end 
+    else begin
+      assign miss_wdata_o = repData32(wbuffer_dirty_mux.data, bdirty_off, miss_size_o[1:0]);
+    end
+  endgenerate
+
   if (ariane_pkg::DATA_USER_EN) begin
     assign miss_wuser_o = riscv::IS_XLEN64 ? repData64(wbuffer_dirty_mux.user, bdirty_off, miss_size_o[1:0]):
                                              repData32(wbuffer_dirty_mux.user, bdirty_off, miss_size_o[1:0]);
@@ -199,8 +206,15 @@ module wt_dcache_wbuffer import ariane_pkg::*; import wt_cache_pkg::*; #(
     assign miss_wuser_o = '0;
   end
 
-  assign tx_be        = riscv::IS_XLEN64 ? to_byte_enable8(bdirty_off, miss_size_o[1:0]):
-                                           to_byte_enable4(bdirty_off, miss_size_o[1:0]);
+generate
+  if (riscv::IS_XLEN64) begin
+    assign tx_be = to_byte_enable8(bdirty_off, miss_size_o[1:0]);
+  end
+  else begin
+    assign tx_be = to_byte_enable4(bdirty_off, miss_size_o[1:0]);
+  end
+endgenerate
+
 
 ///////////////////////////////////////////////////////
 // TX status registers and ID counters

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -211,16 +211,16 @@ module commit_stage import ariane_pkg::*; #(
 
         if (CVA6Cfg.NrCommitPorts > 1) begin
 
-            commit_ack_o[1]    = 1'b0;
-            we_gpr_o[1]        = 1'b0;
-            wdata_o[1]      = commit_instr_i[1].result;
+            commit_ack_o[CVA6Cfg.NrCommitPorts-1]    = 1'b0;
+            we_gpr_o[CVA6Cfg.NrCommitPorts-1]        = 1'b0;
+            wdata_o[CVA6Cfg.NrCommitPorts-1]      = commit_instr_i[CVA6Cfg.NrCommitPorts-1].result;
 
             // -----------------
             // Commit Port 2
             // -----------------
             // check if the second instruction can be committed as well and the first wasn't a CSR instruction
             // also if we are in single step mode don't retire the second instruction
-            if (commit_ack_o[0] && commit_instr_i[1].valid
+            if (commit_ack_o[0] && commit_instr_i[CVA6Cfg.NrCommitPorts-1].valid
                                 && !halt_i
                                 && !(commit_instr_i[0].fu inside {CSR})
                                 && !flush_dcache_i
@@ -228,23 +228,23 @@ module commit_stage import ariane_pkg::*; #(
                                 && !single_step_i) begin
                 // only if the first instruction didn't throw an exception and this instruction won't throw an exception
                 // and the functional unit is of type ALU, LOAD, CTRL_FLOW, MULT, FPU or FPU_VEC
-                if (!exception_o.valid && !commit_instr_i[1].ex.valid
-                                       && (commit_instr_i[1].fu inside {ALU, LOAD, CTRL_FLOW, MULT, FPU, FPU_VEC})) begin
+                if (!exception_o.valid && !commit_instr_i[CVA6Cfg.NrCommitPorts-1].ex.valid
+                                       && (commit_instr_i[CVA6Cfg.NrCommitPorts-1].fu inside {ALU, LOAD, CTRL_FLOW, MULT, FPU, FPU_VEC})) begin
 
                     if (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(commit_instr_i[1].op))
                         we_fpr_o[1] = 1'b1;
                     else
-                        we_gpr_o[1] = 1'b1;
+                        we_gpr_o[CVA6Cfg.NrCommitPorts-1] = 1'b1;
 
-                    commit_ack_o[1] = 1'b1;
+                    commit_ack_o[CVA6Cfg.NrCommitPorts-1] = 1'b1;
 
                     // additionally check if we are retiring an FPU instruction because we need to make sure that we write all
                     // exception flags
                     if (CVA6Cfg.FpPresent && commit_instr_i[1].fu inside {FPU, FPU_VEC}) begin
                         if (csr_write_fflags_o)
-                            csr_wdata_o = {{riscv::XLEN-5{1'b0}}, (commit_instr_i[0].ex.cause[4:0] | commit_instr_i[1].ex.cause[4:0])};
+                            csr_wdata_o = {{riscv::XLEN-5{1'b0}}, (commit_instr_i[0].ex.cause[4:0] | commit_instr_i[CVA6Cfg.NrCommitPorts-1].ex.cause[4:0])};
                         else
-                            csr_wdata_o = {{riscv::XLEN-5{1'b0}}, commit_instr_i[1].ex.cause[4:0]};
+                            csr_wdata_o = {{riscv::XLEN-5{1'b0}}, commit_instr_i[CVA6Cfg.NrCommitPorts-1].ex.cause[4:0]};
 
                         csr_write_fflags_o = 1'b1;
                     end

--- a/core/commit_stage.sv
+++ b/core/commit_stage.sv
@@ -232,7 +232,7 @@ module commit_stage import ariane_pkg::*; #(
                                        && (commit_instr_i[CVA6Cfg.NrCommitPorts-1].fu inside {ALU, LOAD, CTRL_FLOW, MULT, FPU, FPU_VEC})) begin
 
                     if (CVA6Cfg.FpPresent && ariane_pkg::is_rd_fpr(commit_instr_i[1].op))
-                        we_fpr_o[1] = 1'b1;
+                        we_fpr_o[CVA6Cfg.NrCommitPorts-1] = 1'b1;
                     else
                         we_gpr_o[CVA6Cfg.NrCommitPorts-1] = 1'b1;
 

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -270,7 +270,7 @@ module csr_regfile import ariane_pkg::*; #(
                 riscv::CSR_MIMPID:             csr_rdata = '0; // not implemented
                 riscv::CSR_MHARTID:            csr_rdata = hart_id_i;
                 riscv::CSR_MCONFIGPTR:         csr_rdata = '0; // not implemented
-                riscv::CSR_MCOUNTINHIBIT:      csr_rdata = mcountinhibit_q;
+                riscv::CSR_MCOUNTINHIBIT:      csr_rdata = {{(riscv::XLEN-MHPMCounterNum-3){1'b0}},mcountinhibit_q};
                 // Counters and Timers
                 riscv::CSR_MCYCLE:             csr_rdata = cycle_q[riscv::XLEN-1:0];
                 riscv::CSR_MCYCLEH:            if (riscv::XLEN == 32) csr_rdata = cycle_q[63:32]; else read_access_exception = 1'b1;

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -69,7 +69,7 @@ module cvxif_fu import ariane_pkg::*; #(
       x_valid_o             = cvxif_resp_i.x_result_valid; //Read result only when CVXIF is enabled
       x_trans_id_o          = x_valid_o ? cvxif_resp_i.x_result.id : '0;
       x_result_o            = x_valid_o ? cvxif_resp_i.x_result.data : '0;
-      x_exception_o.cause   = x_valid_o ? cvxif_resp_i.x_result.exccode : '0;
+      x_exception_o.cause   = x_valid_o ? {{riscv::XLEN-6{1'b0}},cvxif_resp_i.x_result.exccode} : '0;
       x_exception_o.valid   = x_valid_o ? cvxif_resp_i.x_result.exc : '0;
       x_exception_o.tval    = '0;
       x_we_o                = x_valid_o ? cvxif_resp_i.x_result.we : '0;

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -279,7 +279,7 @@ module instr_queue import ariane_pkg::*; #(
           end
           fetch_entry_o.instruction = instr_data_out[i].instr;
           fetch_entry_o.ex.valid = instr_data_out[i].ex != ariane_pkg::FE_NONE;
-          fetch_entry_o.ex.tval  = {{64-riscv::VLEN{1'b0}}, instr_data_out[i].ex_vaddr};
+          fetch_entry_o.ex.tval  = instr_data_out[i].ex_vaddr;
           fetch_entry_o.branch_predict.cf = instr_data_out[i].cf;
           pop_instr[i] = fetch_entry_valid_o & fetch_entry_ready_i;
         end

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -741,47 +741,47 @@ package ariane_pkg;
     endfunction
 
     // generate byte enable mask
-    function automatic logic [(riscv::XLEN/8)-1:0] be_gen(logic [2:0] addr, logic [1:0] size);
+     function automatic logic [7:0] be_gen(logic [2:0] addr, logic [1:0] size);
         case (size)
             2'b11: begin
-                return {riscv::XLEN/8{1'b1}};
+                return 8'b1111_1111;
             end
             2'b10: begin
                 case (addr[2:0])
-                    3'b000: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/16{1'b1}}};
-                    3'b001: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16{1'b1}},{riscv::XLEN/32-1{1'b0}}};
-                    3'b010: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/16{1'b1}},{riscv::XLEN/32{1'b0}}};
-                    3'b011: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/16{1'b1}},{riscv::XLEN/32+1{1'b0}}};
-                    3'b100: return {{riscv::XLEN/16{1'b1}},  {riscv::XLEN/16{1'b0}}};
+                    3'b000: return 8'b0000_1111;
+                    3'b001: return 8'b0001_1110;
+                    3'b010: return 8'b0011_1100;
+                    3'b011: return 8'b0111_1000;
+                    3'b100: return 8'b1111_0000;
                     default: ; // Do nothing
                 endcase
             end
             2'b01: begin
                 case (addr[2:0])
-                    3'b000: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b1}}};
-                    3'b001: return {{riscv::XLEN/16+1{1'b0}},{riscv::XLEN/32{1'b1}},  {riscv::XLEN/32-1{1'b0}}};
-                    3'b010: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b1}},  {riscv::XLEN/32{1'b0}}};
-                    3'b011: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16-2{1'b1}},{riscv::XLEN/32+1{1'b0}}};
-                    3'b100: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/32{1'b1}},  {riscv::XLEN/16{1'b0}}}; 
-                    3'b101: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/32{1'b1}},  {riscv::XLEN/16+1{1'b0}}};
-                    3'b110: return {{riscv::XLEN/32{1'b1}},  {riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b0}}};
+                    3'b000: return 8'b0000_0011;
+                    3'b001: return 8'b0000_0110;
+                    3'b010: return 8'b0000_1100;
+                    3'b011: return 8'b0001_1000;
+                    3'b100: return 8'b0011_0000;
+                    3'b101: return 8'b0110_0000;
+                    3'b110: return 8'b1100_0000;
                     default: ; // Do nothing
                 endcase
             end
             2'b00: begin
                 case (addr[2:0])
-                    3'b000: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32+1{1'b0}},{riscv::XLEN/32-1{1'b1}}}; 
-                    3'b001: return {{riscv::XLEN/16+2{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32-1{1'b0}}}; 
-                    3'b010: return {{riscv::XLEN/16+1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32{1'b0}}}; 
-                    3'b011: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32+1{1'b0}}}; 
-                    3'b100: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16{1'b0}}}; 
-                    3'b101: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16+1{1'b0}}}; 
-                    3'b110: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16+2{1'b0}}}; 
-                    3'b111: return {{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16{1'b0}}}; 
+                    3'b000: return 8'b0000_0001;
+                    3'b001: return 8'b0000_0010;
+                    3'b010: return 8'b0000_0100;
+                    3'b011: return 8'b0000_1000;
+                    3'b100: return 8'b0001_0000;
+                    3'b101: return 8'b0010_0000;
+                    3'b110: return 8'b0100_0000;
+                    3'b111: return 8'b1000_0000;
                 endcase
             end
         endcase
-        return {riscv::XLEN/8{1'b0}};
+        return 8'b0;
     endfunction
 
     function automatic logic [3:0] be_gen_32(logic [1:0] addr, logic [1:0] size);

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -723,65 +723,65 @@ package ariane_pkg;
     // LSU Functions
     // ----------------------
     // align data to address e.g.: shift data to be naturally 64
-    function automatic riscv::xlen_t data_align (logic [2:0] addr, logic [63:0] data);
+    function automatic riscv::xlen_t data_align (logic [2:0] addr, logic [riscv::XLEN-1:0] data);
         // Set addr[2] to 1'b0 when 32bits
         logic [2:0] addr_tmp = {(addr[2] && riscv::IS_XLEN64), addr[1:0]};
-        logic [63:0] data_tmp = {64{1'b0}};
+        logic [riscv::XLEN-1:0] data_tmp = {riscv::XLEN{1'b0}};
         case (addr_tmp)
             3'b000: data_tmp[riscv::XLEN-1:0] = {data[riscv::XLEN-1:0]};
             3'b001: data_tmp[riscv::XLEN-1:0] = {data[riscv::XLEN-9:0],  data[riscv::XLEN-1:riscv::XLEN-8]};
             3'b010: data_tmp[riscv::XLEN-1:0] = {data[riscv::XLEN-17:0], data[riscv::XLEN-1:riscv::XLEN-16]};
             3'b011: data_tmp[riscv::XLEN-1:0] = {data[riscv::XLEN-25:0], data[riscv::XLEN-1:riscv::XLEN-24]};
-            3'b100: data_tmp = {data[31:0], data[63:32]};
-            3'b101: data_tmp = {data[23:0], data[63:24]};
-            3'b110: data_tmp = {data[15:0], data[63:16]};
-            3'b111: data_tmp = {data[7:0],  data[63:8]};
+            3'b100: data_tmp = {data[riscv::XLEN/2-1:0], data[riscv::XLEN-1:riscv::XLEN/2]};
+            3'b101: data_tmp = {data[23:0], data[riscv::XLEN-1:24]};
+            3'b110: data_tmp = {data[15:0], data[riscv::XLEN-1:16]};
+            3'b111: data_tmp = {data[7:0],  data[riscv::XLEN-1:8]};
         endcase
         return data_tmp[riscv::XLEN-1:0];
     endfunction
 
     // generate byte enable mask
-    function automatic logic [7:0] be_gen(logic [2:0] addr, logic [1:0] size);
+    function automatic logic [(riscv::XLEN/8)-1:0] be_gen(logic [2:0] addr, logic [1:0] size);
         case (size)
             2'b11: begin
-                return 8'b1111_1111;
+                return {riscv::XLEN/8{1'b1}};
             end
             2'b10: begin
                 case (addr[2:0])
-                    3'b000: return 8'b0000_1111;
-                    3'b001: return 8'b0001_1110;
-                    3'b010: return 8'b0011_1100;
-                    3'b011: return 8'b0111_1000;
-                    3'b100: return 8'b1111_0000;
+                    3'b000: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/16{1'b1}}};
+                    3'b001: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16{1'b1}},{riscv::XLEN/32-1{1'b0}}};
+                    3'b010: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/16{1'b1}},{riscv::XLEN/32{1'b0}}};
+                    3'b011: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/16{1'b1}},{riscv::XLEN/32+1{1'b0}}};
+                    3'b100: return {{riscv::XLEN/16{1'b1}},  {riscv::XLEN/16{1'b0}}};
                     default: ; // Do nothing
                 endcase
             end
             2'b01: begin
                 case (addr[2:0])
-                    3'b000: return 8'b0000_0011;
-                    3'b001: return 8'b0000_0110;
-                    3'b010: return 8'b0000_1100;
-                    3'b011: return 8'b0001_1000;
-                    3'b100: return 8'b0011_0000;
-                    3'b101: return 8'b0110_0000;
-                    3'b110: return 8'b1100_0000;
+                    3'b000: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b1}}};
+                    3'b001: return {{riscv::XLEN/16+1{1'b0}},{riscv::XLEN/32{1'b1}},  {riscv::XLEN/32-1{1'b0}}};
+                    3'b010: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b1}},  {riscv::XLEN/32{1'b0}}};
+                    3'b011: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16-2{1'b1}},{riscv::XLEN/32+1{1'b0}}};
+                    3'b100: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/32{1'b1}},  {riscv::XLEN/16{1'b0}}}; 
+                    3'b101: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/32{1'b1}},  {riscv::XLEN/16+1{1'b0}}};
+                    3'b110: return {{riscv::XLEN/32{1'b1}},  {riscv::XLEN/16{1'b0}},  {riscv::XLEN/32{1'b0}}};
                     default: ; // Do nothing
                 endcase
             end
             2'b00: begin
                 case (addr[2:0])
-                    3'b000: return 8'b0000_0001;
-                    3'b001: return 8'b0000_0010;
-                    3'b010: return 8'b0000_0100;
-                    3'b011: return 8'b0000_1000;
-                    3'b100: return 8'b0001_0000;
-                    3'b101: return 8'b0010_0000;
-                    3'b110: return 8'b0100_0000;
-                    3'b111: return 8'b1000_0000;
+                    3'b000: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32+1{1'b0}},{riscv::XLEN/32-1{1'b1}}}; 
+                    3'b001: return {{riscv::XLEN/16+2{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32-1{1'b0}}}; 
+                    3'b010: return {{riscv::XLEN/16+1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32{1'b0}}}; 
+                    3'b011: return {{riscv::XLEN/16{1'b0}},  {riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32+1{1'b0}}}; 
+                    3'b100: return {{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16{1'b0}}}; 
+                    3'b101: return {{riscv::XLEN/32{1'b0}},  {riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16+1{1'b0}}}; 
+                    3'b110: return {{riscv::XLEN/32-1{1'b0}},{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/16+2{1'b0}}}; 
+                    3'b111: return {{riscv::XLEN/32-1{1'b1}},{riscv::XLEN/32+1{1'b0}},{riscv::XLEN/16{1'b0}}}; 
                 endcase
             end
         endcase
-        return 8'b0;
+        return {riscv::XLEN/8{1'b0}};
     endfunction
 
     function automatic logic [3:0] be_gen_32(logic [1:0] addr, logic [1:0] size);

--- a/core/include/wt_cache_pkg.sv
+++ b/core/include/wt_cache_pkg.sv
@@ -115,7 +115,7 @@ package wt_cache_pkg;
     logic                                            vld;         // invalidate only affected way
     logic                                            all;         // invalidate all ways
     logic [ariane_pkg::ICACHE_INDEX_WIDTH-1:0]       idx;         // physical address to invalidate
-    logic [L15_WAY_WIDTH-1:0]                        way;         // way to invalidate
+    logic [$clog2(ariane_pkg::ICACHE_SET_ASSOC)-1:0] way;         // way to invalidate
   } icache_inval_t;
 
   typedef struct packed {
@@ -267,11 +267,11 @@ package wt_cache_pkg;
     return cnt;
   endfunction : popcnt64
 
-  function automatic logic [7:0] to_byte_enable8(
-    input logic [2:0] offset,
+  function automatic logic [(riscv::XLEN/8)-1:0] to_byte_enable8(
+    input logic [$clog2(riscv::XLEN/8)-1:0] offset,
     input logic [1:0] size
   );
-    logic [7:0] be;
+    logic [(riscv::XLEN/8)-1:0] be;
     be = '0;
     unique case(size)
       2'b00:   be[offset]       = '1; // byte
@@ -297,12 +297,12 @@ package wt_cache_pkg;
   endfunction : to_byte_enable4
 
   // openpiton requires the data to be replicated in case of smaller sizes than dwords
-  function automatic logic [63:0] repData64(
-    input logic [63:0] data,
-    input logic [2:0]  offset,
+  function automatic logic [riscv::XLEN-1:0] repData64(
+    input logic [riscv::XLEN-1:0] data,
+    input logic [$clog2(riscv::XLEN/8)-1:0]  offset,
     input logic [1:0]  size
   );
-    logic [63:0] out;
+    logic [riscv::XLEN-1:0] out;
     unique case(size)
       2'b00:   for(int k=0; k<8; k++) out[k*8  +: 8]    = data[offset*8 +: 8];  // byte
       2'b01:   for(int k=0; k<4; k++) out[k*16 +: 16]   = data[offset*8 +: 16]; // hword

--- a/core/include/wt_cache_pkg.sv
+++ b/core/include/wt_cache_pkg.sv
@@ -267,11 +267,11 @@ package wt_cache_pkg;
     return cnt;
   endfunction : popcnt64
 
-  function automatic logic [(riscv::XLEN/8)-1:0] to_byte_enable8(
-    input logic [$clog2(riscv::XLEN/8)-1:0] offset,
+  function automatic logic [7:0] to_byte_enable8(
+    input logic [2:0] offset,
     input logic [1:0] size
   );
-    logic [(riscv::XLEN/8)-1:0] be;
+    logic [7:0] be;
     be = '0;
     unique case(size)
       2'b00:   be[offset]       = '1; // byte
@@ -297,12 +297,12 @@ package wt_cache_pkg;
   endfunction : to_byte_enable4
 
   // openpiton requires the data to be replicated in case of smaller sizes than dwords
-  function automatic logic [riscv::XLEN-1:0] repData64(
-    input logic [riscv::XLEN-1:0] data,
-    input logic [$clog2(riscv::XLEN/8)-1:0]  offset,
+  function automatic logic [63:0] repData64(
+    input logic [63:0] data,
+    input logic [2:0]  offset,
     input logic [1:0]  size
   );
-    logic [riscv::XLEN-1:0] out;
+    logic [63:0] out;
     unique case(size)
       2'b00:   for(int k=0; k<8; k++) out[k*8  +: 8]    = data[offset*8 +: 8];  // byte
       2'b01:   for(int k=0; k<4; k++) out[k*16 +: 16]   = data[offset*8 +: 16]; // hword

--- a/core/instr_realign.sv
+++ b/core/instr_realign.sv
@@ -97,7 +97,7 @@ module instr_realign import ariane_pkg::*; #(
                     unaligned_instr_d = data_i[15:0];
                 // the instruction isn't compressed but only the lower is ready
                 end else begin
-                    valid_o = 1'b1;
+                    valid_o = {{(INSTR_PER_FETCH-1){1'b0}},1'b1};
                 end
             end
         end

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -413,8 +413,15 @@ module issue_read_operands import ariane_pkg::*; #(
     logic [CVA6Cfg.NrCommitPorts-1:0][4:0]  waddr_pack;
     logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_pack;
     logic [CVA6Cfg.NrCommitPorts-1:0]       we_pack;
-    assign raddr_pack = CVA6Cfg.NrRgprPorts == 3 ? {{riscv::XLEN/32-1{issue_instr_i.result[4:0]}}, issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]}
-                                           : {issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]};
+    generate
+        if (CVA6Cfg.NrRgprPorts == 3) begin
+          assign raddr_pack = {issue_instr_i.result[4:0], issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]};
+        end 
+        else begin
+          assign raddr_pack = {issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]};
+        end
+    endgenerate
+
     for (genvar i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin : gen_write_back_port
         assign waddr_pack[i] = waddr_i[i];
         assign wdata_pack[i] = wdata_i[i];

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -239,7 +239,7 @@ module issue_read_operands import ariane_pkg::*; #(
         end
 
         if (forward_rs3) begin
-            imm_n  = CVA6Cfg.NrRgprPorts == 3 ? rs3_i : {{riscv::XLEN-CVA6Cfg.FLen{1'b0}}, rs3_i};;
+            imm_n  = CVA6Cfg.NrRgprPorts == 3 ? {{riscv::XLEN-1{1'b0}},rs3_i} : {{riscv::XLEN-CVA6Cfg.FLen{1'b0}}, rs3_i};;
         end
 
         // use the PC as operand a
@@ -413,7 +413,7 @@ module issue_read_operands import ariane_pkg::*; #(
     logic [CVA6Cfg.NrCommitPorts-1:0][4:0]  waddr_pack;
     logic [CVA6Cfg.NrCommitPorts-1:0][riscv::XLEN-1:0] wdata_pack;
     logic [CVA6Cfg.NrCommitPorts-1:0]       we_pack;
-    assign raddr_pack = CVA6Cfg.NrRgprPorts == 3 ? {issue_instr_i.result[4:0], issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]}
+    assign raddr_pack = CVA6Cfg.NrRgprPorts == 3 ? {{riscv::XLEN/32-1{issue_instr_i.result[4:0]}}, issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]}
                                            : {issue_instr_i.rs2[4:0], issue_instr_i.rs1[4:0]};
     for (genvar i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin : gen_write_back_port
         assign waddr_pack[i] = waddr_i[i];

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -377,8 +377,14 @@ module load_store_unit import ariane_pkg::*; #(
     // we can generate the byte enable from the virtual address since the last
     // 12 bit are the same anyway
     // and we can always generate the byte enable from the address at hand
-    assign be_i = riscv::IS_XLEN64 ? be_gen(vaddr_i[2:0], extract_transfer_size(fu_data_i.operation)):
-                                     be_gen_32(vaddr_i[1:0], extract_transfer_size(fu_data_i.operation));
+    generate
+        if (riscv::IS_XLEN64) begin
+            assign be_i = be_gen(vaddr_i[2:0], extract_transfer_size(fu_data_i.operation));
+        end 
+        else begin
+            assign be_i = be_gen_32(vaddr_i[1:0], extract_transfer_size(fu_data_i.operation));
+        end
+    endgenerate
 
     // ------------------------
     // Misaligned Exception

--- a/core/load_unit.sv
+++ b/core/load_unit.sv
@@ -175,7 +175,7 @@ module load_unit import ariane_pkg::*; #(
     logic not_commit_time;
     logic inflight_stores;
     logic stall_ni;
-    assign paddr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {dtlb_ppn_i,12'd0});
+    assign paddr_ni = config_pkg::is_inside_nonidempotent_regions(CVA6Cfg, {{52-riscv::PPNW{1'b0}},{dtlb_ppn_i,12'd0}});
     assign not_commit_time = commit_tran_id_i != lsu_ctrl_i.trans_id;
     assign inflight_stores = (!dcache_wbuffer_not_ni_i || !store_buffer_empty_i);
     assign stall_ni = (inflight_stores || not_commit_time) && paddr_ni;

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -274,7 +274,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
         if (riscv::PLEN > riscv::VLEN)
             icache_areq_o.fetch_paddr = {{riscv::PLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};// play through in case we disabled address translation
         else
-            icache_areq_o.fetch_paddr = icache_areq_i.fetch_vaddr[riscv::PLEN-1:0];// play through in case we disabled address translation
+            icache_areq_o.fetch_paddr = {{riscv::PLEN-32{1'b0}},icache_areq_i.fetch_vaddr[31:0]};// play through in case we disabled address translation
         // two potential exception sources:
         // 1. HPTW threw an exception -> signal with a page fault exception
         // 2. We got an access error because of insufficient permissions -> throw an access exception
@@ -387,8 +387,8 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
             lsu_paddr_o           = {{riscv::PLEN-riscv::VLEN{1'b0}}, lsu_vaddr_q};
             lsu_dtlb_ppn_o        = {{riscv::PLEN-riscv::VLEN{1'b0}},lsu_vaddr_n[riscv::VLEN-1:12]};
         end else begin
-            lsu_paddr_o           = lsu_vaddr_q[riscv::PLEN-1:0];
-            lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::PPNW-1:0]; // changing as per TL
+            lsu_paddr_o           = {{riscv::PLEN-32{1'b0}},lsu_vaddr_q[31:0]};
+            lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::PPNW-1:0]; 
         end
         lsu_valid_o           = lsu_req_q;
         lsu_exception_o       = misaligned_ex_q;

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -388,7 +388,7 @@ module cva6_mmu_sv32 import ariane_pkg::*; #(
             lsu_dtlb_ppn_o        = {{riscv::PLEN-riscv::VLEN{1'b0}},lsu_vaddr_n[riscv::VLEN-1:12]};
         end else begin
             lsu_paddr_o           = lsu_vaddr_q[riscv::PLEN-1:0];
-            lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::VLEN-1:12];
+            lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::PPNW-1:0]; // changing as per TL
         end
         lsu_valid_o           = lsu_req_q;
         lsu_exception_o       = misaligned_ex_q;

--- a/core/pmp/src/pmp_entry.sv
+++ b/core/pmp/src/pmp_entry.sv
@@ -33,7 +33,7 @@ module pmp_entry #(
     logic [PLEN-1:0] base;
     logic [PLEN-1:0] mask;
     int unsigned size;
-    assign conf_addr_n = ~conf_addr_i;
+    assign conf_addr_n = {{PLEN-PMP_LEN{1'b1}},~conf_addr_i};
     lzc #(.WIDTH(PLEN), .MODE(1'b0)) i_lzc(
         .in_i    ( conf_addr_n ),
         .cnt_o   ( trail_ones  ),
@@ -48,15 +48,15 @@ module pmp_entry #(
                 size = '0;
                 // check that the requested address is in between the two
                 // configuration addresses
-                if (addr_i >= (conf_addr_prev_i << 2) && addr_i < (conf_addr_i << 2)) begin
+                if (addr_i >= ({{PLEN-PMP_LEN{1'b0}},conf_addr_prev_i} << 2) && addr_i < ({{PLEN-PMP_LEN{1'b0}},conf_addr_i} << 2)) begin
                     match_o = 1'b1;
                 end else match_o = 1'b0;
 
                 // synthesis translate_off
                 if (match_o == 0) begin
-                    assert(addr_i >= (conf_addr_i << 2) || addr_i < (conf_addr_prev_i << 2));
+                    assert(addr_i >= ({{PLEN-PMP_LEN{1'b0}},conf_addr_i} << 2) || addr_i < ({{PLEN-PMP_LEN{1'b0}},conf_addr_prev_i} << 2));
                 end else begin
-                    assert(addr_i < (conf_addr_i << 2) && addr_i >= (conf_addr_prev_i << 2));
+                    assert(addr_i < ({{PLEN-PMP_LEN{1'b0}},conf_addr_i} << 2) && addr_i >= ({{PLEN-PMP_LEN{1'b0}},conf_addr_prev_i} << 2));
                 end
                 // synthesis translate_on
 
@@ -66,11 +66,11 @@ module pmp_entry #(
                 if (conf_addr_mode_i == riscv::NA4) size = 2;
                 else begin
                     // use the extracted trailing ones
-                    size = trail_ones+3;
+                    size = {{26{1'b0}},trail_ones}+3;
                 end
 
                 mask = '1 << size;
-                base = (conf_addr_i << 2) & mask;
+                base = ({{PLEN-PMP_LEN{1'b0}},conf_addr_i} << 2) & mask;
                 match_o = (addr_i & mask) == base ? 1'b1 : 1'b0;
 
                 // synthesis translate_off

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -176,7 +176,7 @@ module scoreboard #(
         // save the target address of a branch (needed for debug in commit stage)
         mem_n[trans_id_i[i]].sbe.bp.predict_address = resolved_branch_i.target_address;
         if (mem_n[trans_id_i[i]].sbe.fu == ariane_pkg::CVXIF && ~x_we_i) begin
-          mem_n[trans_id_i[i]].sbe.rd = 5'b0;
+          mem_n[trans_id_i[i]].sbe.rd = '0;
         end
         // write the exception back if it is valid
         if (ex_i[i].valid)
@@ -192,7 +192,7 @@ module scoreboard #(
     // Commit Port
     // ------------
     // we've got an acknowledge from commit
-    for (logic [CVA6Cfg.NrCommitPorts-1:0] i = 0; i < CVA6Cfg.NrCommitPorts; i++) begin
+    for (logic [CVA6Cfg.NrCommitPorts-1:0] i = 0; i < CVA6Cfg.NrCommitPorts[CVA6Cfg.NrCommitPorts-1:0]; i++) begin
       if (commit_ack_i[i]) begin
         // this instruction is no longer in issue e.g.: it is considered finished
         mem_n[commit_pointer_q[i]].issued     = 1'b0;
@@ -216,7 +216,7 @@ module scoreboard #(
   // FIFO counter updates
   assign num_commit = (CVA6Cfg.NrCommitPorts == 2) ? commit_ack_i[1] + commit_ack_i[0] : commit_ack_i[0];
 
-  assign issue_cnt_n         = (flush_i) ? '0 : issue_cnt_q         - num_commit + issue_en;
+  assign issue_cnt_n         = (flush_i) ? '0 : issue_cnt_q - {{(BITS_ENTRIES-$clog2(CVA6Cfg.NrCommitPorts)){1'b0}},num_commit} + {{(BITS_ENTRIES){1'b0}},issue_en};
   assign commit_pointer_n[0] = (flush_i) ? '0 : commit_pointer_q[0] + num_commit;
   assign issue_pointer_n     = (flush_i) ? '0 : issue_pointer_q     + issue_en;
 

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -214,7 +214,7 @@ module scoreboard #(
   end
 
   // FIFO counter updates
-  assign num_commit = (CVA6Cfg.NrCommitPorts == 2) ? commit_ack_i[1] + commit_ack_i[0] : commit_ack_i[0];
+  assign num_commit = (CVA6Cfg.NrCommitPorts == 2) ? commit_ack_i[CVA6Cfg.NrCommitPorts-1] + commit_ack_i[0] : commit_ack_i[0];
 
   assign issue_cnt_n         = (flush_i) ? '0 : issue_cnt_q - {{(BITS_ENTRIES-$clog2(CVA6Cfg.NrCommitPorts)){1'b0}},num_commit} + {{(BITS_ENTRIES){1'b0}},issue_en};
   assign commit_pointer_n[0] = (flush_i) ? '0 : commit_pointer_q[0] + num_commit;
@@ -422,7 +422,7 @@ module scoreboard #(
     else $fatal (1,"Commit acknowledged but instruction is not valid");
 
   assert property (
-    @(posedge clk_i) disable iff (!rst_ni) commit_ack_i[1] |-> commit_instr_o[1].valid)
+    @(posedge clk_i) disable iff (!rst_ni) commit_ack_i[CVA6Cfg.NrCommitPorts-1] |-> commit_instr_o[CVA6Cfg.NrCommitPorts-1].valid)
     else $fatal (1,"Commit acknowledged but instruction is not valid");
 
   // assert that we never give an issue ack signal if the instruction is not valid

--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -107,8 +107,8 @@ module serdiv import ariane_pkg::*; #(
     .empty_o ( lzc_b_no_one )
   );
 
-  assign shift_a      = (lzc_a_no_one) ? WIDTH : lzc_a_result;
-  assign div_shift    = lzc_b_result - shift_a;
+  assign shift_a      = (lzc_a_no_one) ? WIDTH : {1'b0,lzc_a_result};
+  assign div_shift    = {1'b0,lzc_b_result} - shift_a;
 
   assign op_b         = op_b_i <<< $unsigned(div_shift);
 

--- a/core/store_buffer.sv
+++ b/core/store_buffer.sv
@@ -60,8 +60,10 @@ module store_buffer import ariane_pkg::*; #(
       commit_queue_n [DEPTH_COMMIT-1:0],    commit_queue_q [DEPTH_COMMIT-1:0];
 
     // keep a status count for both buffers
-    logic [$clog2(DEPTH_SPEC):0] speculative_status_cnt_n, speculative_status_cnt_q;
-    logic [$clog2(DEPTH_COMMIT):0] commit_status_cnt_n, commit_status_cnt_q;
+    logic [$clog2(DEPTH_SPEC):0] speculative_status_cnt_n, speculative_status_cnt_q, depth_spec;
+    assign depth_spec = DEPTH_SPEC[$clog2(DEPTH_SPEC):0];
+    logic [$clog2(DEPTH_COMMIT):0] commit_status_cnt_n, commit_status_cnt_q,depth_commit;
+    assign depth_commit = DEPTH_COMMIT[$clog2(DEPTH_COMMIT):0];
     // Speculative queue
     logic [$clog2(DEPTH_SPEC)-1:0] speculative_read_pointer_n,  speculative_read_pointer_q;
     logic [$clog2(DEPTH_SPEC)-1:0] speculative_write_pointer_n, speculative_write_pointer_q;
@@ -78,7 +80,7 @@ module store_buffer import ariane_pkg::*; #(
         speculative_status_cnt = speculative_status_cnt_q;
 
         // we are ready if the speculative and the commit queue have a space left
-        ready_o = (speculative_status_cnt_q < (DEPTH_SPEC - 1)) || commit_i;
+        ready_o = (speculative_status_cnt_q < (depth_spec - 1)) || commit_i;
         // default assignments
         speculative_status_cnt_n    = speculative_status_cnt_q;
         speculative_read_pointer_n  = speculative_read_pointer_q;
@@ -149,7 +151,7 @@ module store_buffer import ariane_pkg::*; #(
         automatic logic [$clog2(DEPTH_COMMIT):0] commit_status_cnt;
         commit_status_cnt = commit_status_cnt_q;
 
-        commit_ready_o = (commit_status_cnt_q < DEPTH_COMMIT);
+        commit_ready_o = (commit_status_cnt_q < depth_commit);
         // no store is pending if we don't have any element in the commit queue e.g.: it is empty
         no_st_pending_o         = (commit_status_cnt_q == 0);
         // default assignments
@@ -268,7 +270,7 @@ module store_buffer import ariane_pkg::*; #(
         else $error ("[Commit Queue] You are trying to commit and flush in the same cycle");
 
     speculative_buffer_overflow: assert property (
-        @(posedge clk_i) rst_ni && (speculative_status_cnt_q == DEPTH_SPEC) |-> !valid_i)
+        @(posedge clk_i) rst_ni && (speculative_status_cnt_q == depth_spec) |-> !valid_i)
         else $error ("[Speculative Queue] You are trying to push new data although the buffer is not ready");
 
     speculative_buffer_underflow: assert property (
@@ -276,7 +278,7 @@ module store_buffer import ariane_pkg::*; #(
         else $error ("[Speculative Queue] You are committing although there are no stores to commit");
 
     commit_buffer_overflow: assert property (
-        @(posedge clk_i) rst_ni && (commit_status_cnt_q == DEPTH_COMMIT) |-> !commit_i)
+        @(posedge clk_i) rst_ni && (commit_status_cnt_q == depth_commit) |-> !commit_i)
         else $error("[Commit Queue] You are trying to commit a store although the buffer is full");
     //pragma translate_on
 endmodule


### PR DESCRIPTION
This Pull Request effectively addresses and resolves the `WIDTHEXPAND` type warnings that were flagged by the Verilator lint tool. 

A total of 32 warnings have been successfully resolved.

By implementing the changes proposed in this Pull Request, we can significantly enhance the code quality and maintainability, while ensuring adherence to coding standards and practices.