### PR TITLE
SFENCE.VMA cases for MMUSV32 Shared TLB 

### DIFF
--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -26,85 +26,83 @@
 // 2020-02-17  0.1      S.Jacq       MMU Sv32 for CV32A6
 // =========================================================================== //
 
-module cva6_mmu_sv32
-  import ariane_pkg::*;
-#(
-    parameter config_pkg::cva6_cfg_t CVA6Cfg           = config_pkg::cva6_cfg_empty,
-    parameter int unsigned           INSTR_TLB_ENTRIES = 2,
-    parameter int unsigned           DATA_TLB_ENTRIES  = 2,
-    parameter int unsigned           ASID_WIDTH        = 1
+module cva6_mmu_sv32 import ariane_pkg::*; #(
+  parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+  parameter int unsigned INSTR_TLB_ENTRIES     = 2,
+  parameter int unsigned DATA_TLB_ENTRIES      = 2,
+  parameter int unsigned ASID_WIDTH            = 1
 ) (
-    input logic clk_i,
-    input logic rst_ni,
-    input logic flush_i,
-    input logic enable_translation_i,
-    input logic en_ld_st_translation_i,  // enable virtual memory translation for load/stores
-    // IF interface
-    input icache_arsp_t icache_areq_i,
-    output icache_areq_t icache_areq_o,
-    // LSU interface
-    // this is a more minimalistic interface because the actual addressing logic is handled
-    // in the LSU as we distinguish load and stores, what we do here is simple address translation
-    input exception_t misaligned_ex_i,
-    input logic lsu_req_i,  // request address translation
-    input logic [riscv::VLEN-1:0] lsu_vaddr_i,  // virtual address in
-    input logic lsu_is_store_i,  // the translation is requested by a store
-    // if we need to walk the page table we can't grant in the same cycle
-    // Cycle 0
-    output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
-    output logic [riscv::PPNW-1:0] lsu_dtlb_ppn_o,  // ppn (send same cycle as hit)
-    // Cycle 1
-    output logic lsu_valid_o,  // translation is valid
-    output logic [riscv::PLEN-1:0] lsu_paddr_o,  // translated address
-    output exception_t lsu_exception_o,  // address translation threw an exception
-    // General control signals
-    input riscv::priv_lvl_t priv_lvl_i,
-    input riscv::priv_lvl_t ld_st_priv_lvl_i,
-    input logic sum_i,
-    input logic mxr_i,
-    // input logic flag_mprv_i,
-    input logic [riscv::PPNW-1:0] satp_ppn_i,
-    input logic [ASID_WIDTH-1:0] asid_i,
-    input logic [ASID_WIDTH-1:0] asid_to_be_flushed_i,
-    input logic [riscv::VLEN-1:0] vaddr_to_be_flushed_i,
-    input logic flush_tlb_i,
-    // Performance counters
-    output logic itlb_miss_o,
-    output logic dtlb_miss_o,
-    // PTW memory interface
-    input dcache_req_o_t req_port_i,
-    output dcache_req_i_t req_port_o,
-    // PMP
-    input riscv::pmpcfg_t [15:0] pmpcfg_i,
-    input logic [15:0][riscv::PLEN-3:0] pmpaddr_i
+  input  logic                            clk_i,
+  input  logic                            rst_ni,
+  input  logic                            flush_i,
+  input  logic                            enable_translation_i,
+  input  logic                            en_ld_st_translation_i,   // enable virtual memory translation for load/stores
+  // IF interface
+  input  icache_arsp_t                  icache_areq_i,
+  output icache_areq_t                  icache_areq_o,
+  // LSU interface
+  // this is a more minimalistic interface because the actual addressing logic is handled
+  // in the LSU as we distinguish load and stores, what we do here is simple address translation
+  input  exception_t                      misaligned_ex_i,
+  input  logic                            lsu_req_i,        // request address translation
+  input  logic [riscv::VLEN-1:0]          lsu_vaddr_i,      // virtual address in
+  input  logic                            lsu_is_store_i,   // the translation is requested by a store
+  // if we need to walk the page table we can't grant in the same cycle
+  // Cycle 0
+  output logic                            lsu_dtlb_hit_o,   // sent in the same cycle as the request if translation hits in the DTLB
+  output logic [riscv::PPNW-1:0]          lsu_dtlb_ppn_o,   // ppn (send same cycle as hit)
+  // Cycle 1
+  output logic                            lsu_valid_o,      // translation is valid
+  output logic [riscv::PLEN-1:0]          lsu_paddr_o,      // translated address
+  output exception_t                      lsu_exception_o,  // address translation threw an exception
+  // General control signals
+  input riscv::priv_lvl_t                 priv_lvl_i,
+  input riscv::priv_lvl_t                 ld_st_priv_lvl_i,
+  input logic                             sum_i,
+  input logic                             mxr_i,
+  // input logic flag_mprv_i,
+  input logic [riscv::PPNW-1:0]           satp_ppn_i,
+  input logic [ASID_WIDTH-1:0]            asid_i,
+  input logic [ASID_WIDTH-1:0]            asid_to_be_flushed_i,
+  input logic [riscv::VLEN-1:0]           vaddr_to_be_flushed_i,
+  input logic                             flush_tlb_i,
+  // Performance counters
+  output logic                            itlb_miss_o,
+  output logic                            dtlb_miss_o,
+  // PTW memory interface
+  input  dcache_req_o_t                   req_port_i,
+  output dcache_req_i_t                   req_port_o,
+  // PMP
+  input  riscv::pmpcfg_t [15:0]           pmpcfg_i,
+  input  logic [15:0][riscv::PLEN-3:0]    pmpaddr_i
 );
 
-  logic                   iaccess_err;  // insufficient privilege to access this instruction page
-  logic                   daccess_err;  // insufficient privilege to access this data page
-  logic                   ptw_active;  // PTW is currently walking a page table
-  logic                   walking_instr;  // PTW is walking because of an ITLB miss
-  logic                   ptw_error;  // PTW threw an exception
-  logic                   ptw_access_exception;  // PTW threw an access exception (PMPs)
-  logic [riscv::PLEN-1:0] ptw_bad_paddr;  // PTW PMP exception bad physical addr
+  logic                   iaccess_err;   // insufficient privilege to access this instruction page
+  logic                   daccess_err;   // insufficient privilege to access this data page
+  logic                   ptw_active;    // PTW is currently walking a page table
+  logic                   walking_instr; // PTW is walking because of an ITLB miss
+  logic                   ptw_error;     // PTW threw an exception
+  logic                   ptw_access_exception; // PTW threw an access exception (PMPs)
+  logic [riscv::PLEN-1:0] ptw_bad_paddr; // PTW PMP exception bad physical addr
 
   logic [riscv::VLEN-1:0] update_vaddr;
   tlb_update_sv32_t update_itlb, update_dtlb, update_shared_tlb;
 
-  logic                               itlb_lu_access;
-  riscv::pte_sv32_t                   itlb_content;
-  logic                               itlb_is_4M;
-  logic                               itlb_lu_hit;
+  logic             itlb_lu_access;
+  riscv::pte_sv32_t itlb_content;
+  logic             itlb_is_4M;
+  logic             itlb_lu_hit;
 
-  logic                               dtlb_lu_access;
-  riscv::pte_sv32_t                   dtlb_content;
-  logic                               dtlb_is_4M;
-  logic                               dtlb_lu_hit;
+  logic             dtlb_lu_access;
+  riscv::pte_sv32_t dtlb_content;
+  logic             dtlb_is_4M;
+  logic             dtlb_lu_hit;
 
-  logic                               shared_tlb_access;
-  logic             [riscv::VLEN-1:0] shared_tlb_vaddr;
-  logic                               shared_tlb_hit;
+  logic                     shared_tlb_access;
+  logic [riscv::VLEN-1:0]   shared_tlb_vaddr;
+  logic                     shared_tlb_hit;
 
-  logic                               itlb_req;
+  logic             itlb_req;
 
 
   // Assignments
@@ -113,136 +111,139 @@ module cva6_mmu_sv32
 
 
   cva6_tlb_sv32 #(
-      .CVA6Cfg    (CVA6Cfg),
-      .TLB_ENTRIES(INSTR_TLB_ENTRIES),
-      .ASID_WIDTH (ASID_WIDTH)
+      .CVA6Cfg          ( CVA6Cfg                    ),
+      .TLB_ENTRIES      ( INSTR_TLB_ENTRIES          ),
+      .ASID_WIDTH       ( ASID_WIDTH                 )
   ) i_itlb (
-      .clk_i  (clk_i),
-      .rst_ni (rst_ni),
-      .flush_i(flush_tlb_i),
+      .clk_i            ( clk_i                      ),
+      .rst_ni           ( rst_ni                     ),
+      .flush_i          ( flush_tlb_i                ),
 
-      .update_i(update_itlb),
+      .update_i         ( update_itlb                ),
 
-      .lu_access_i          (itlb_lu_access),
-      .lu_asid_i            (asid_i),
-      .asid_to_be_flushed_i (asid_to_be_flushed_i),
-      .vaddr_to_be_flushed_i(vaddr_to_be_flushed_i),
-      .lu_vaddr_i           (icache_areq_i.fetch_vaddr),
-      .lu_content_o         (itlb_content),
+      .lu_access_i      ( itlb_lu_access             ),
+      .lu_asid_i        ( asid_i                     ),
+      .asid_to_be_flushed_i  ( asid_to_be_flushed_i  ),
+      .vaddr_to_be_flushed_i ( vaddr_to_be_flushed_i ),
+      .lu_vaddr_i       ( icache_areq_i.fetch_vaddr  ),
+      .lu_content_o     ( itlb_content               ),
 
-      .lu_is_4M_o(itlb_is_4M),
-      .lu_hit_o  (itlb_lu_hit)
+      .lu_is_4M_o       ( itlb_is_4M                 ),
+      .lu_hit_o         ( itlb_lu_hit                )
   );
 
   cva6_tlb_sv32 #(
-      .CVA6Cfg    (CVA6Cfg),
-      .TLB_ENTRIES(DATA_TLB_ENTRIES),
-      .ASID_WIDTH (ASID_WIDTH)
+      .CVA6Cfg         ( CVA6Cfg                     ),
+      .TLB_ENTRIES     ( DATA_TLB_ENTRIES            ),
+      .ASID_WIDTH      ( ASID_WIDTH                  )
   ) i_dtlb (
-      .clk_i  (clk_i),
-      .rst_ni (rst_ni),
-      .flush_i(flush_tlb_i),
+      .clk_i            ( clk_i                      ),
+      .rst_ni           ( rst_ni                     ),
+      .flush_i          ( flush_tlb_i                ),
 
-      .update_i(update_dtlb),
+      .update_i         ( update_dtlb                ),
 
-      .lu_access_i          (dtlb_lu_access),
-      .lu_asid_i            (asid_i),
-      .asid_to_be_flushed_i (asid_to_be_flushed_i),
-      .vaddr_to_be_flushed_i(vaddr_to_be_flushed_i),
-      .lu_vaddr_i           (lsu_vaddr_i),
-      .lu_content_o         (dtlb_content),
+      .lu_access_i      ( dtlb_lu_access             ),
+      .lu_asid_i        ( asid_i                     ),
+      .asid_to_be_flushed_i  ( asid_to_be_flushed_i  ),
+      .vaddr_to_be_flushed_i ( vaddr_to_be_flushed_i ),
+      .lu_vaddr_i       ( lsu_vaddr_i                ),
+      .lu_content_o     ( dtlb_content               ),
 
-      .lu_is_4M_o(dtlb_is_4M),
-      .lu_hit_o  (dtlb_lu_hit)
+      .lu_is_4M_o       ( dtlb_is_4M                 ),
+      .lu_hit_o         ( dtlb_lu_hit                )
   );
 
   cva6_shared_tlb_sv32 #(
-      .CVA6Cfg         (CVA6Cfg),
-      .SHARED_TLB_DEPTH(64),
-      .SHARED_TLB_WAYS (2),
-      .ASID_WIDTH      (ASID_WIDTH)
+      .CVA6Cfg          ( CVA6Cfg  ),
+      .SHARED_TLB_DEPTH ( 64 ),
+      .SHARED_TLB_WAYS  ( 2 ),
+      .ASID_WIDTH ( ASID_WIDTH )
   ) i_shared_tlb (
-      .clk_i  (clk_i),
-      .rst_ni (rst_ni),
-      .flush_i(flush_tlb_i),
+      .clk_i            ( clk_i                       ),
+      .rst_ni           ( rst_ni                      ),
+      .flush_i          ( flush_tlb_i                 ),
 
-      .enable_translation_i  (enable_translation_i),
-      .en_ld_st_translation_i(en_ld_st_translation_i),
+      .enable_translation_i   ( enable_translation_i  ),
+      .en_ld_st_translation_i ( en_ld_st_translation_i),
 
-      .asid_i       (asid_i),
+      .asid_i                (asid_i                  ),
+      .asid_to_be_flushed_i  ( asid_to_be_flushed_i   ),
+      .vaddr_to_be_flushed_i ( vaddr_to_be_flushed_i  ),
+
       // from TLBs
       // did we miss?
-      .itlb_access_i(itlb_lu_access),
-      .itlb_hit_i   (itlb_lu_hit),
-      .itlb_vaddr_i (icache_areq_i.fetch_vaddr),
+      .itlb_access_i    ( itlb_lu_access              ),
+      .itlb_hit_i       ( itlb_lu_hit                 ),
+      .itlb_vaddr_i     ( icache_areq_i.fetch_vaddr   ),
 
-      .dtlb_access_i(dtlb_lu_access),
-      .dtlb_hit_i   (dtlb_lu_hit),
-      .dtlb_vaddr_i (lsu_vaddr_i),
+      .dtlb_access_i    ( dtlb_lu_access              ),
+      .dtlb_hit_i       ( dtlb_lu_hit                 ),
+      .dtlb_vaddr_i     ( lsu_vaddr_i                 ),
 
       // to TLBs, update logic
-      .itlb_update_o(update_itlb),
-      .dtlb_update_o(update_dtlb),
+      .itlb_update_o    ( update_itlb                 ),
+      .dtlb_update_o    ( update_dtlb                 ),
 
       // Performance counters
-      .itlb_miss_o(itlb_miss_o),
-      .dtlb_miss_o(dtlb_miss_o),
+      .itlb_miss_o      (itlb_miss_o                  ),
+      .dtlb_miss_o      (dtlb_miss_o                  ),
 
-      .shared_tlb_access_o(shared_tlb_access),
-      .shared_tlb_hit_o   (shared_tlb_hit),
-      .shared_tlb_vaddr_o (shared_tlb_vaddr),
+      .shared_tlb_access_o ( shared_tlb_access        ),
+      .shared_tlb_hit_o    ( shared_tlb_hit           ),
+      .shared_tlb_vaddr_o  ( shared_tlb_vaddr         ),
 
-      .itlb_req_o         (itlb_req),
+      .itlb_req_o          ( itlb_req                 ),
       // to update shared tlb
-      .shared_tlb_update_i(update_shared_tlb)
+      .shared_tlb_update_i (update_shared_tlb         )
   );
 
-  cva6_ptw_sv32 #(
-      .CVA6Cfg   (CVA6Cfg),
-      .ASID_WIDTH(ASID_WIDTH)
+  cva6_ptw_sv32  #(
+      .CVA6Cfg                ( CVA6Cfg               ),
+      .ASID_WIDTH             ( ASID_WIDTH            )
   ) i_ptw (
-      .clk_i  (clk_i),
-      .rst_ni (rst_ni),
-      .flush_i(flush_i),
+      .clk_i                  ( clk_i                 ),
+      .rst_ni                 ( rst_ni                ),
+      .flush_i                ( flush_i ),
 
-      .ptw_active_o          (ptw_active),
-      .walking_instr_o       (walking_instr),
-      .ptw_error_o           (ptw_error),
-      .ptw_access_exception_o(ptw_access_exception),
+      .ptw_active_o           ( ptw_active            ),
+      .walking_instr_o        ( walking_instr         ),
+      .ptw_error_o            ( ptw_error             ),
+      .ptw_access_exception_o ( ptw_access_exception  ),
 
-      .lsu_is_store_i(lsu_is_store_i),
-      // PTW memory interface
-      .req_port_i    (req_port_i),
-      .req_port_o    (req_port_o),
+      .lsu_is_store_i         ( lsu_is_store_i        ),
+       // PTW memory interface
+      .req_port_i             ( req_port_i            ),
+      .req_port_o             ( req_port_o            ),
 
       // to Shared TLB, update logic
-      .shared_tlb_update_o(update_shared_tlb),
+      .shared_tlb_update_o    ( update_shared_tlb     ),
 
-      .update_vaddr_o(update_vaddr),
+      .update_vaddr_o         ( update_vaddr          ),
 
-      .asid_i(asid_i),
+      .asid_i                 ( asid_i                ),
 
       // from shared TLB
       // did we miss?
-      .shared_tlb_access_i(shared_tlb_access),
-      .shared_tlb_hit_i   (shared_tlb_hit),
-      .shared_tlb_vaddr_i (shared_tlb_vaddr),
+      .shared_tlb_access_i    ( shared_tlb_access     ),
+      .shared_tlb_hit_i       ( shared_tlb_hit        ),
+      .shared_tlb_vaddr_i     ( shared_tlb_vaddr      ),
 
-      .itlb_req_i(itlb_req),
+      .itlb_req_i             ( itlb_req              ),
 
       // from CSR file
-      .satp_ppn_i(satp_ppn_i),  // ppn from satp
-      .mxr_i     (mxr_i),
+     .satp_ppn_i              ( satp_ppn_i            ), // ppn from satp
+     .mxr_i                   ( mxr_i                 ),
 
-      // Performance counters
-      .shared_tlb_miss_o(),  //open for now
+     // Performance counters
+     .shared_tlb_miss_o       (                       ), //open for now
 
-      // PMP
-      .pmpcfg_i   (pmpcfg_i),
-      .pmpaddr_i  (pmpaddr_i),
-      .bad_paddr_o(ptw_bad_paddr)
+     // PMP
+    .pmpcfg_i                 ( pmpcfg_i              ),
+    .pmpaddr_i                ( pmpaddr_i             ),
+    .bad_paddr_o              ( ptw_bad_paddr         )
 
-  );
+);
 
   // ila_1 i_ila_1 (
   //     .clk(clk_i), // input wire clk
@@ -271,293 +272,252 @@ module cva6_mmu_sv32
 
   // The instruction interface is a simple request response interface
   always_comb begin : instr_interface
-    // MMU disabled: just pass through
-    icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
-    if (riscv::PLEN > riscv::VLEN)
-      icache_areq_o.fetch_paddr = {
-        {riscv::PLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr
-      };  // play through in case we disabled address translation
-    else
-      icache_areq_o.fetch_paddr = {2'b00, icache_areq_i.fetch_vaddr[riscv::VLEN-1:0]};// play through in case we disabled address translation
-    // two potential exception sources:
-    // 1. HPTW threw an exception -> signal with a page fault exception
-    // 2. We got an access error because of insufficient permissions -> throw an access exception
-    icache_areq_o.fetch_exception = '0;
-    // Check whether we are allowed to access this memory region from a fetch perspective
-    iaccess_err   = icache_areq_i.fetch_req && (((priv_lvl_i == riscv::PRIV_LVL_U) && ~itlb_content.u)
-                                                 || ((priv_lvl_i == riscv::PRIV_LVL_S) && itlb_content.u));
+      // MMU disabled: just pass through
+      icache_areq_o.fetch_valid  = icache_areq_i.fetch_req;
+      if (riscv::PLEN > riscv::VLEN)
+          icache_areq_o.fetch_paddr = {{riscv::PLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr};// play through in case we disabled address translation
+      else
+          icache_areq_o.fetch_paddr = icache_areq_i.fetch_vaddr[riscv::PLEN-1:0];// play through in case we disabled address translation
+      // two potential exception sources:
+      // 1. HPTW threw an exception -> signal with a page fault exception
+      // 2. We got an access error because of insufficient permissions -> throw an access exception
+      icache_areq_o.fetch_exception      = '0;
+      // Check whether we are allowed to access this memory region from a fetch perspective
+      iaccess_err   = icache_areq_i.fetch_req && (((priv_lvl_i == riscv::PRIV_LVL_U) && ~itlb_content.u)
+                                               || ((priv_lvl_i == riscv::PRIV_LVL_S) && itlb_content.u));
 
-    // MMU enabled: address from TLB, request delayed until hit. Error when TLB
-    // hit and no access right or TLB hit and translated address not valid (e.g.
-    // AXI decode error), or when PTW performs walk due to ITLB miss and raises
-    // an error.
-    if (enable_translation_i) begin
-      // we work with SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
-      if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
-        icache_areq_o.fetch_exception = {
-          riscv::INSTR_ACCESS_FAULT,
-          {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-          1'b1
-        };
+      // MMU enabled: address from TLB, request delayed until hit. Error when TLB
+      // hit and no access right or TLB hit and translated address not valid (e.g.
+      // AXI decode error), or when PTW performs walk due to ITLB miss and raises
+      // an error.
+      if (enable_translation_i) begin
+          // we work with SV32, so if VM is enabled, check that all bits [riscv::VLEN-1:riscv::SV-1] are equal
+          if (icache_areq_i.fetch_req && !((&icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b1 || (|icache_areq_i.fetch_vaddr[riscv::VLEN-1:riscv::SV-1]) == 1'b0)) begin
+              icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};
+          end
+
+          icache_areq_o.fetch_valid = 1'b0;
+
+          // 4K page
+          icache_areq_o.fetch_paddr = {itlb_content.ppn, icache_areq_i.fetch_vaddr[11:0]};
+          // Mega page
+          if (itlb_is_4M) begin
+              icache_areq_o.fetch_paddr[21:12] = icache_areq_i.fetch_vaddr[21:12];
+          end
+
+
+          // ---------
+          // ITLB Hit
+          // --------
+          // if we hit the ITLB output the request signal immediately
+          if (itlb_lu_hit) begin
+              icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
+              // we got an access error
+              if (iaccess_err) begin
+                  // throw a page fault
+                  icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr}, 1'b1};//to check on wave --> not connected
+              end else if (!pmp_instr_allow) begin
+                  icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, icache_areq_i.fetch_vaddr, 1'b1};//to check on wave --> not connected
+              end
+          end else
+          // ---------
+          // ITLB Miss
+          // ---------
+          // watch out for exceptions happening during walking the page table
+          if (ptw_active && walking_instr) begin
+              icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
+              if (ptw_error) icache_areq_o.fetch_exception = {riscv::INSTR_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{1'b0}}, update_vaddr}, 1'b1};//to check on wave
+              // TODO(moschn,zarubaf): What should the value of tval be in this case?
+              else icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1};//to check on wave --> not connected
+          end
       end
-
-      icache_areq_o.fetch_valid = 1'b0;
-
-      // 4K page
-      icache_areq_o.fetch_paddr = {itlb_content.ppn, icache_areq_i.fetch_vaddr[11:0]};
-      // Mega page
-      if (itlb_is_4M) begin
-        icache_areq_o.fetch_paddr[21:12] = icache_areq_i.fetch_vaddr[21:12];
+      // if it didn't match any execute region throw an `Instruction Access Fault`
+      // or: if we are not translating, check PMPs immediately on the paddr
+      if (!match_any_execute_region || (!enable_translation_i && !pmp_instr_allow)) begin
+        icache_areq_o.fetch_exception = {riscv::INSTR_ACCESS_FAULT, icache_areq_o.fetch_paddr[riscv::PLEN-1:2], 1'b1};//to check on wave --> not connected
       end
-
-
-      // ---------
-      // ITLB Hit
-      // --------
-      // if we hit the ITLB output the request signal immediately
-      if (itlb_lu_hit) begin
-        icache_areq_o.fetch_valid = icache_areq_i.fetch_req;
-        // we got an access error
-        if (iaccess_err) begin
-          // throw a page fault
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT,
-            {{riscv::XLEN - riscv::VLEN{1'b0}}, icache_areq_i.fetch_vaddr},
-            1'b1
-          };  //to check on wave --> not connected
-        end else if (!pmp_instr_allow) begin
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT, icache_areq_i.fetch_vaddr, 1'b1
-          };  //to check on wave --> not connected
-        end
-      end else
-      // ---------
-      // ITLB Miss
-      // ---------
-      // watch out for exceptions happening during walking the page table
-      if (ptw_active && walking_instr) begin
-        icache_areq_o.fetch_valid = ptw_error | ptw_access_exception;
-        if (ptw_error)
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_PAGE_FAULT, {{riscv::XLEN - riscv::VLEN{1'b0}}, update_vaddr}, 1'b1
-          };  //to check on wave
-        // TODO(moschn,zarubaf): What should the value of tval be in this case?
-        else
-          icache_areq_o.fetch_exception = {
-            riscv::INSTR_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1
-          };  //to check on wave --> not connected
-      end
-    end
-    // if it didn't match any execute region throw an `Instruction Access Fault`
-    // or: if we are not translating, check PMPs immediately on the paddr
-    if (!match_any_execute_region || (!enable_translation_i && !pmp_instr_allow)) begin
-      icache_areq_o.fetch_exception = {
-        riscv::INSTR_ACCESS_FAULT, icache_areq_o.fetch_paddr[riscv::PLEN-1:2], 1'b1
-      };  //to check on wave --> not connected
-    end
   end
 
   // check for execute flag on memory
-  assign match_any_execute_region = config_pkg::is_inside_execute_regions(
-      CVA6Cfg, {{64 - riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr}
-  );
+  assign match_any_execute_region = config_pkg::is_inside_execute_regions(CVA6Cfg, {{64-riscv::PLEN{1'b0}}, icache_areq_o.fetch_paddr});
 
   // Instruction fetch
   pmp #(
-      .PLEN      (riscv::PLEN),
-      .PMP_LEN   (riscv::PLEN - 2),
-      .NR_ENTRIES(CVA6Cfg.NrPMPEntries)
+      .PLEN       ( riscv::PLEN            ),
+      .PMP_LEN    ( riscv::PLEN - 2        ),
+      .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
   ) i_pmp_if (
-      .addr_i       (icache_areq_o.fetch_paddr),
+      .addr_i        ( icache_areq_o.fetch_paddr ),
       .priv_lvl_i,
       // we will always execute on the instruction fetch port
-      .access_type_i(riscv::ACCESS_EXEC),
+      .access_type_i ( riscv::ACCESS_EXEC        ),
       // Configuration
-      .conf_addr_i  (pmpaddr_i),
-      .conf_i       (pmpcfg_i),
-      .allow_o      (pmp_instr_allow)
+      .conf_addr_i   ( pmpaddr_i                 ),
+      .conf_i        ( pmpcfg_i                  ),
+      .allow_o       ( pmp_instr_allow           )
   );
 
   //-----------------------
   // Data Interface
   //-----------------------
-  logic [riscv::VLEN-1:0] lsu_vaddr_n, lsu_vaddr_q;
-  riscv::pte_sv32_t dtlb_pte_n, dtlb_pte_q;
-  exception_t misaligned_ex_n, misaligned_ex_q;
-  logic lsu_req_n, lsu_req_q;
-  logic lsu_is_store_n, lsu_is_store_q;
-  logic dtlb_hit_n, dtlb_hit_q;
-  logic dtlb_is_4M_n, dtlb_is_4M_q;
+  logic [riscv::VLEN-1:0] lsu_vaddr_n,     lsu_vaddr_q;
+  riscv::pte_sv32_t dtlb_pte_n,      dtlb_pte_q;
+  exception_t  misaligned_ex_n, misaligned_ex_q;
+  logic        lsu_req_n,       lsu_req_q;
+  logic        lsu_is_store_n,  lsu_is_store_q;
+  logic        dtlb_hit_n,      dtlb_hit_q;
+  logic        dtlb_is_4M_n,    dtlb_is_4M_q;
 
   // check if we need to do translation or if we are always ready (e.g.: we are not translating anything)
-  assign lsu_dtlb_hit_o = (en_ld_st_translation_i) ? dtlb_lu_hit : 1'b1;
+  assign lsu_dtlb_hit_o = (en_ld_st_translation_i) ? dtlb_lu_hit :  1'b1;
 
   // Wires to PMP checks
   riscv::pmp_access_t pmp_access_type;
-  logic               pmp_data_allow;
-  localparam PPNWMin = (riscv::PPNW - 1 > 29) ? 29 : riscv::PPNW - 1;
+  logic        pmp_data_allow;
+  localparam   PPNWMin = (riscv::PPNW-1 > 29) ? 29 : riscv::PPNW-1;
   // The data interface is simpler and only consists of a request/response interface
   always_comb begin : data_interface
-    // save request and DTLB response
-    lsu_vaddr_n     = lsu_vaddr_i;
-    lsu_req_n       = lsu_req_i;
-    misaligned_ex_n = misaligned_ex_i;
-    dtlb_pte_n      = dtlb_content;
-    dtlb_hit_n      = dtlb_lu_hit;
-    lsu_is_store_n  = lsu_is_store_i;
-    dtlb_is_4M_n    = dtlb_is_4M;
+      // save request and DTLB response
+      lsu_vaddr_n           = lsu_vaddr_i;
+      lsu_req_n             = lsu_req_i;
+      misaligned_ex_n       = misaligned_ex_i;
+      dtlb_pte_n            = dtlb_content;
+      dtlb_hit_n            = dtlb_lu_hit;
+      lsu_is_store_n        = lsu_is_store_i;
+      dtlb_is_4M_n          = dtlb_is_4M;
 
-    if (riscv::PLEN > riscv::VLEN) begin
-      lsu_paddr_o    = {{riscv::PLEN - riscv::VLEN{1'b0}}, lsu_vaddr_q};
-      lsu_dtlb_ppn_o = {{riscv::PLEN - riscv::VLEN{1'b0}}, lsu_vaddr_n[riscv::VLEN-1:12]};
-    end else begin
-      lsu_paddr_o    = {2'b00, lsu_vaddr_q[riscv::VLEN-1:0]};
-      lsu_dtlb_ppn_o = lsu_vaddr_n[riscv::PPNW-1:0];
-    end
-    lsu_valid_o = lsu_req_q;
-    lsu_exception_o = misaligned_ex_q;
-    pmp_access_type = lsu_is_store_q ? riscv::ACCESS_WRITE : riscv::ACCESS_READ;
-
-    // mute misaligned exceptions if there is no request otherwise they will throw accidental exceptions
-    misaligned_ex_n.valid = misaligned_ex_i.valid & lsu_req_i;
-
-    // Check if the User flag is set, then we may only access it in supervisor mode
-    // if SUM is enabled
-    daccess_err = (ld_st_priv_lvl_i == riscv::PRIV_LVL_S && !sum_i && dtlb_pte_q.u) || // SUM is not set and we are trying to access a user page in supervisor mode
-    (ld_st_priv_lvl_i == riscv::PRIV_LVL_U && !dtlb_pte_q.u);            // this is not a user page but we are in user mode and trying to access it
-    // translation is enabled and no misaligned exception occurred
-    if (en_ld_st_translation_i && !misaligned_ex_q.valid) begin
-      lsu_valid_o = 1'b0;
-      // 4K page
-      lsu_paddr_o = {dtlb_pte_q.ppn, lsu_vaddr_q[11:0]};
-      lsu_dtlb_ppn_o = dtlb_content.ppn;
-      // Mega page
-      if (dtlb_is_4M_q) begin
-        lsu_paddr_o[21:12] = lsu_vaddr_q[21:12];
-        lsu_dtlb_ppn_o[21:12] = lsu_vaddr_n[21:12];
-      end
-      // ---------
-      // DTLB Hit
-      // --------
-      if (dtlb_hit_q && lsu_req_q) begin
-        lsu_valid_o = 1'b1;
-        // exception priority:
-        // PAGE_FAULTS have higher priority than ACCESS_FAULTS
-        // virtual memory based exceptions are PAGE_FAULTS
-        // physical memory based exceptions are ACCESS_FAULTS (PMA/PMP)
-
-        // this is a store
-        if (lsu_is_store_q) begin
-          // check if the page is write-able and we are not violating privileges
-          // also check if the dirty flag is set
-          if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };  //to check on wave
-            // Check if any PMPs are violated
-          end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1
-            };  //only 32 bits on 34b of lsu_paddr_o are returned.
-          end
-
-          // this is a load
-        end else begin
-          // check for sufficient access privileges - throw a page fault if necessary
-          if (daccess_err) begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, lsu_vaddr_q},
-              1'b1
-            };
-            // Check if any PMPs are violated
-          end else if (!pmp_data_allow) begin
-            lsu_exception_o = {
-              riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1
-            };  //only 32 bits on 34b of lsu_paddr_o are returned.
-          end
-        end
-      end else
-
-      // ---------
-      // DTLB Miss
-      // ---------
-      // watch out for exceptions
-      if (ptw_active && !walking_instr) begin
-        // page table walker threw an exception
-        if (ptw_error) begin
-          // an error makes the translation valid
-          lsu_valid_o = 1'b1;
-          // the page table walker can only throw page faults
-          if (lsu_is_store_q) begin
-            lsu_exception_o = {
-              riscv::STORE_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
-          end else begin
-            lsu_exception_o = {
-              riscv::LOAD_PAGE_FAULT,
-              {{riscv::XLEN - riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}}, update_vaddr},
-              1'b1
-            };
-          end
-        end
-
-        if (ptw_access_exception) begin
-          // an error makes the translation valid
-          lsu_valid_o = 1'b1;
-          // the page table walker can only throw page faults
-          lsu_exception_o = {riscv::LD_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1};
-        end
-      end
-    end  // If translation is not enabled, check the paddr immediately against PMPs
-    else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
-      if (lsu_is_store_q) begin
-        lsu_exception_o = {riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+      if (riscv::PLEN > riscv::VLEN) begin
+          lsu_paddr_o           = {{riscv::PLEN-riscv::VLEN{1'b0}}, lsu_vaddr_q};
+          lsu_dtlb_ppn_o        = {{riscv::PLEN-riscv::VLEN{1'b0}},lsu_vaddr_n[riscv::VLEN-1:12]};
       end else begin
-        lsu_exception_o = {riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+          lsu_paddr_o           = lsu_vaddr_q[riscv::PLEN-1:0];
+          lsu_dtlb_ppn_o        = lsu_vaddr_n[riscv::PPNW-1:0];
       end
-    end
+      lsu_valid_o           = lsu_req_q;
+      lsu_exception_o       = misaligned_ex_q;
+      pmp_access_type       = lsu_is_store_q ? riscv::ACCESS_WRITE : riscv::ACCESS_READ;
+
+      // mute misaligned exceptions if there is no request otherwise they will throw accidental exceptions
+      misaligned_ex_n.valid = misaligned_ex_i.valid & lsu_req_i;
+
+      // Check if the User flag is set, then we may only access it in supervisor mode
+      // if SUM is enabled
+      daccess_err = (ld_st_priv_lvl_i == riscv::PRIV_LVL_S && !sum_i && dtlb_pte_q.u) || // SUM is not set and we are trying to access a user page in supervisor mode
+                    (ld_st_priv_lvl_i == riscv::PRIV_LVL_U && !dtlb_pte_q.u);            // this is not a user page but we are in user mode and trying to access it
+      // translation is enabled and no misaligned exception occurred
+      if (en_ld_st_translation_i && !misaligned_ex_q.valid) begin
+          lsu_valid_o = 1'b0;
+          // 4K page
+          lsu_paddr_o = {dtlb_pte_q.ppn, lsu_vaddr_q[11:0]};
+          lsu_dtlb_ppn_o = dtlb_content.ppn;
+          // Mega page
+          if (dtlb_is_4M_q) begin
+            lsu_paddr_o[21:12] = lsu_vaddr_q[21:12];
+            lsu_dtlb_ppn_o[21:12] = lsu_vaddr_n[21:12];
+          end
+          // ---------
+          // DTLB Hit
+          // --------
+          if (dtlb_hit_q && lsu_req_q) begin
+              lsu_valid_o = 1'b1;
+              // exception priority:
+              // PAGE_FAULTS have higher priority than ACCESS_FAULTS
+              // virtual memory based exceptions are PAGE_FAULTS
+              // physical memory based exceptions are ACCESS_FAULTS (PMA/PMP)
+
+              // this is a store
+              if (lsu_is_store_q) begin
+                  // check if the page is write-able and we are not violating privileges
+                  // also check if the dirty flag is set
+                  if (!dtlb_pte_q.w || daccess_err || !dtlb_pte_q.d) begin
+                      lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1}; //to check on wave
+                  // Check if any PMPs are violated
+                  end else if (!pmp_data_allow) begin
+                      lsu_exception_o = {riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1}; //only 32 bits on 34b of lsu_paddr_o are returned.
+                  end
+
+              // this is a load
+              end else begin
+                  // check for sufficient access privileges - throw a page fault if necessary
+                  if (daccess_err) begin
+                      lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},lsu_vaddr_q}, 1'b1};
+                  // Check if any PMPs are violated
+                  end else if (!pmp_data_allow) begin
+                      lsu_exception_o = {riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1}; //only 32 bits on 34b of lsu_paddr_o are returned.
+                  end
+              end
+          end else
+
+          // ---------
+          // DTLB Miss
+          // ---------
+          // watch out for exceptions
+          if (ptw_active && !walking_instr) begin
+              // page table walker threw an exception
+              if (ptw_error) begin
+                  // an error makes the translation valid
+                  lsu_valid_o = 1'b1;
+                  // the page table walker can only throw page faults
+                  if (lsu_is_store_q) begin
+                      lsu_exception_o = {riscv::STORE_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
+                  end else begin
+                      lsu_exception_o = {riscv::LOAD_PAGE_FAULT, {{riscv::XLEN-riscv::VLEN{lsu_vaddr_q[riscv::VLEN-1]}},update_vaddr}, 1'b1};
+                  end
+              end
+
+              if (ptw_access_exception) begin
+                  // an error makes the translation valid
+                  lsu_valid_o = 1'b1;
+                  // the page table walker can only throw page faults
+                  lsu_exception_o = {riscv::LD_ACCESS_FAULT, ptw_bad_paddr[riscv::PLEN-1:2], 1'b1};
+              end
+          end
+      end
+      // If translation is not enabled, check the paddr immediately against PMPs
+      else if (lsu_req_q && !misaligned_ex_q.valid && !pmp_data_allow) begin
+          if (lsu_is_store_q) begin
+              lsu_exception_o = {riscv::ST_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+          end else begin
+              lsu_exception_o = {riscv::LD_ACCESS_FAULT, lsu_paddr_o[riscv::PLEN-1:2], 1'b1};
+          end
+      end
   end
 
   // Load/store PMP check
   pmp #(
-      .PLEN      (riscv::PLEN),
-      .PMP_LEN   (riscv::PLEN - 2),
-      .NR_ENTRIES(CVA6Cfg.NrPMPEntries)
+      .PLEN       ( riscv::PLEN            ),
+      .PMP_LEN    ( riscv::PLEN - 2        ),
+      .NR_ENTRIES ( CVA6Cfg.NrPMPEntries   )
   ) i_pmp_data (
-      .addr_i       (lsu_paddr_o),
-      .priv_lvl_i   (ld_st_priv_lvl_i),
-      .access_type_i(pmp_access_type),
+      .addr_i        ( lsu_paddr_o         ),
+      .priv_lvl_i    ( ld_st_priv_lvl_i    ),
+      .access_type_i ( pmp_access_type     ),
       // Configuration
-      .conf_addr_i  (pmpaddr_i),
-      .conf_i       (pmpcfg_i),
-      .allow_o      (pmp_data_allow)
+      .conf_addr_i   ( pmpaddr_i           ),
+      .conf_i        ( pmpcfg_i            ),
+      .allow_o       ( pmp_data_allow      )
   );
 
   // ----------
   // Registers
   // ----------
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      lsu_vaddr_q     <= '0;
-      lsu_req_q       <= '0;
-      misaligned_ex_q <= '0;
-      dtlb_pte_q      <= '0;
-      dtlb_hit_q      <= '0;
-      lsu_is_store_q  <= '0;
-      dtlb_is_4M_q    <= '0;
-    end else begin
-      lsu_vaddr_q     <= lsu_vaddr_n;
-      lsu_req_q       <= lsu_req_n;
-      misaligned_ex_q <= misaligned_ex_n;
-      dtlb_pte_q      <= dtlb_pte_n;
-      dtlb_hit_q      <= dtlb_hit_n;
-      lsu_is_store_q  <= lsu_is_store_n;
-      dtlb_is_4M_q    <= dtlb_is_4M_n;
-    end
+      if (~rst_ni) begin
+          lsu_vaddr_q      <= '0;
+          lsu_req_q        <= '0;
+          misaligned_ex_q  <= '0;
+          dtlb_pte_q       <= '0;
+          dtlb_hit_q       <= '0;
+          lsu_is_store_q   <= '0;
+          dtlb_is_4M_q     <= '0;
+      end else begin
+          lsu_vaddr_q      <=  lsu_vaddr_n;
+          lsu_req_q        <=  lsu_req_n;
+          misaligned_ex_q  <=  misaligned_ex_n;
+          dtlb_pte_q       <=  dtlb_pte_n;
+          dtlb_hit_q       <=  dtlb_hit_n;
+          lsu_is_store_q   <=  lsu_is_store_n;
+          dtlb_is_4M_q     <=  dtlb_is_4M_n;
+      end
   end
 endmodule

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -17,351 +17,406 @@
 
 /* verilator lint_off WIDTH */
 
-module cva6_shared_tlb_sv32
-  import ariane_pkg::*;
-#(
+module cva6_shared_tlb_sv32 import ariane_pkg::*; #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int SHARED_TLB_DEPTH = 64,
     parameter int SHARED_TLB_WAYS = 2,
     parameter int ASID_WIDTH = 1
 ) (
-    input logic clk_i,   // Clock
-    input logic rst_ni,  // Asynchronous reset active low
-    input logic flush_i,
+input  logic                    clk_i,                  // Clock
+input  logic                    rst_ni,                 // Asynchronous reset active low
+input  logic                    flush_i,
 
-    input logic enable_translation_i,   // CSRs indicate to enable SV32
-    input logic en_ld_st_translation_i, // enable virtual memory translation for load/stores
+input  logic                    enable_translation_i,   // CSRs indicate to enable SV32
+input  logic                    en_ld_st_translation_i, // enable virtual memory translation for load/stores
 
-    input logic [ASID_WIDTH-1:0] asid_i,
+// input logic flag_mprv_i,
+input  logic [ASID_WIDTH-1:0]   asid_i,
+input  logic [ASID_WIDTH-1:0]   asid_to_be_flushed_i,
+input  logic [riscv::VLEN-1:0]  vaddr_to_be_flushed_i,
 
-    // from TLBs
-    // did we miss?
-    input logic                   itlb_access_i,
-    input logic                   itlb_hit_i,
-    input logic [riscv::VLEN-1:0] itlb_vaddr_i,
+// from TLBs
+// did we miss?
+input  logic                    itlb_access_i,
+input  logic                    itlb_hit_i,
+input  logic [riscv::VLEN-1:0]  itlb_vaddr_i,
 
-    input logic                   dtlb_access_i,
-    input logic                   dtlb_hit_i,
-    input logic [riscv::VLEN-1:0] dtlb_vaddr_i,
+input  logic                    dtlb_access_i,
+input  logic                    dtlb_hit_i,
+input  logic [riscv::VLEN-1:0]  dtlb_vaddr_i,
 
-    // to TLBs, update logic
-    output tlb_update_sv32_t itlb_update_o,
-    output tlb_update_sv32_t dtlb_update_o,
+// to TLBs, update logic
+output tlb_update_sv32_t        itlb_update_o,
+output tlb_update_sv32_t        dtlb_update_o,
 
-    // Performance counters
-    output logic itlb_miss_o,
-    output logic dtlb_miss_o,
+// Performance counters
+output logic                    itlb_miss_o,
+output logic                    dtlb_miss_o,
 
-    output logic                   shared_tlb_access_o,
-    output logic                   shared_tlb_hit_o,
-    output logic [riscv::VLEN-1:0] shared_tlb_vaddr_o,
+output logic                    shared_tlb_access_o,
+output logic                    shared_tlb_hit_o,
+output logic [riscv::VLEN-1:0]  shared_tlb_vaddr_o,
 
-    output logic itlb_req_o,
+output logic                    itlb_req_o,
 
-    // Update shared TLB in case of miss
-    input tlb_update_sv32_t shared_tlb_update_i
+// Update shared TLB in case of miss
+input  tlb_update_sv32_t        shared_tlb_update_i
 
 );
 
-  function logic [SHARED_TLB_WAYS-1:0] shared_tlb_way_bin2oh(input logic [$clog2(SHARED_TLB_WAYS
-)-1:0] in);
-    logic [SHARED_TLB_WAYS-1:0] out;
-    out     = '0;
-    out[in] = 1'b1;
-    return out;
-  endfunction
+function logic [SHARED_TLB_WAYS-1:0] shared_tlb_way_bin2oh ( input logic [$clog2(SHARED_TLB_WAYS)-1:0] in);
+  logic [SHARED_TLB_WAYS-1:0] out;
+  out     = '0;
+  out[in] = 1'b1;
+  return out;
+endfunction
 
-  typedef struct packed {
-    logic [8:0] asid;   //9 bits wide
-    logic [9:0] vpn1;   //10 bits wide
-    logic [9:0] vpn0;   //10 bits wide
-    logic       is_4M;
-  } shared_tag_t;
+typedef struct packed {
+  logic [9:0]            vpn1; //10 bits wide
+  logic [9:0]            vpn0; //10 bits wide
+  logic                  is_4M;
+} shared_tag_t;
 
-  shared_tag_t shared_tag_wr;
-  shared_tag_t [SHARED_TLB_WAYS-1:0] shared_tag_rd;
+typedef logic [ASID_WIDTH-1:0] shared_asid_t;
 
-  logic [SHARED_TLB_DEPTH-1:0][SHARED_TLB_WAYS-1:0] shared_tag_valid_q, shared_tag_valid_d;
+shared_tag_t shared_tag_wr;
+shared_tag_t [SHARED_TLB_WAYS-1:0] shared_tag_rd;
 
-  logic [         SHARED_TLB_WAYS-1:0] shared_tag_valid;
+shared_asid_t [SHARED_TLB_DEPTH-1:0][SHARED_TLB_WAYS-1:0] shared_asid_q, shared_asid_d;
+shared_asid_t [SHARED_TLB_WAYS-1:0] shared_asid;
 
-  logic [         SHARED_TLB_WAYS-1:0] tag_wr_en;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_wr_addr;
-  logic [     $bits(shared_tag_t)-1:0] tag_wr_data;
+logic [SHARED_TLB_DEPTH-1:0][SHARED_TLB_WAYS-1:0] shared_tag_valid_q, shared_tag_valid_d ;
 
-  logic [         SHARED_TLB_WAYS-1:0] tag_rd_en;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_rd_addr;
-  logic [     $bits(shared_tag_t)-1:0] tag_rd_data      [SHARED_TLB_WAYS-1:0];
+logic [SHARED_TLB_WAYS-1:0]          shared_tag_valid;
 
-  logic [         SHARED_TLB_WAYS-1:0] tag_req;
-  logic [         SHARED_TLB_WAYS-1:0] tag_we;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_addr;
+logic [SHARED_TLB_WAYS-1:0]          tag_wr_en;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_wr_addr;
+logic [$bits(shared_tag_t)-1:0]      tag_wr_data;
 
-  logic [         SHARED_TLB_WAYS-1:0] pte_wr_en;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_wr_addr;
-  logic [$bits(riscv::pte_sv32_t)-1:0] pte_wr_data;
+logic [SHARED_TLB_WAYS-1:0]          tag_rd_en;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_rd_addr;
+logic [$bits(shared_tag_t)-1:0]      tag_rd_data [SHARED_TLB_WAYS-1:0];
 
-  logic [         SHARED_TLB_WAYS-1:0] pte_rd_en;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_rd_addr;
-  logic [$bits(riscv::pte_sv32_t)-1:0] pte_rd_data      [SHARED_TLB_WAYS-1:0];
+logic [SHARED_TLB_WAYS-1:0]          tag_req;
+logic [SHARED_TLB_WAYS-1:0]          tag_we;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] tag_addr;
 
-  logic [         SHARED_TLB_WAYS-1:0] pte_req;
-  logic [         SHARED_TLB_WAYS-1:0] pte_we;
-  logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_addr;
+logic [SHARED_TLB_WAYS-1:0]          pte_wr_en;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_wr_addr;
+logic [$bits(riscv::pte_sv32_t)-1:0] pte_wr_data;
 
-  logic [9:0] vpn0_d, vpn1_d, vpn0_q, vpn1_q;
+logic [SHARED_TLB_WAYS-1:0]          pte_rd_en;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_rd_addr;
+logic [$bits(riscv::pte_sv32_t)-1:0] pte_rd_data [SHARED_TLB_WAYS-1:0];
 
-  riscv::pte_sv32_t [SHARED_TLB_WAYS-1:0] pte;
+logic [SHARED_TLB_WAYS-1:0]          pte_req;
+logic [SHARED_TLB_WAYS-1:0]          pte_we;
+logic [$clog2(SHARED_TLB_DEPTH)-1:0] pte_addr;
 
-  logic [riscv::VLEN-1-12:0] itlb_vpn_q;
-  logic [riscv::VLEN-1-12:0] dtlb_vpn_q;
+logic [9:0] vpn0_d, vpn1_d, vpn0_q, vpn1_q;
 
-  logic [ASID_WIDTH-1:0] tlb_update_asid_q, tlb_update_asid_d;
+riscv::pte_sv32_t [SHARED_TLB_WAYS-1:0] pte;
 
-  logic shared_tlb_access_q, shared_tlb_access_d;
-  logic shared_tlb_hit_d;
-  logic [riscv::VLEN-1:0] shared_tlb_vaddr_q, shared_tlb_vaddr_d;
+logic [riscv::VLEN-1-12:0]  itlb_vpn_q;
+logic [riscv::VLEN-1-12:0]  dtlb_vpn_q;
 
-  logic itlb_req_d, itlb_req_q;
-  logic dtlb_req_d, dtlb_req_q;
+logic [ASID_WIDTH-1:0] tlb_update_asid_q, tlb_update_asid_d;
 
-  // replacement strategy
-  logic [SHARED_TLB_WAYS-1:0] way_valid;
-  logic update_lfsr;  // shift the LFSR
-  logic [$clog2(SHARED_TLB_WAYS)-1:0] inv_way;  // first non-valid encountered
-  logic [$clog2(SHARED_TLB_WAYS)-1:0] rnd_way;  // random index for replacement
-  logic [$clog2(SHARED_TLB_WAYS)-1:0] repl_way;  // way to replace
-  logic [SHARED_TLB_WAYS-1:0] repl_way_oh_d;  // way to replace (onehot)
-  logic all_ways_valid;  // we need to switch repl strategy since all are valid
+logic                   shared_tlb_access_q, shared_tlb_access_d;
+logic                   shared_tlb_hit_d;
+logic [riscv::VLEN-1:0] shared_tlb_vaddr_q, shared_tlb_vaddr_d;
 
-  assign shared_tlb_access_o = shared_tlb_access_q;
-  assign shared_tlb_hit_o = shared_tlb_hit_d;
-  assign shared_tlb_vaddr_o = shared_tlb_vaddr_q;
+logic itlb_req_d, itlb_req_q;
+logic dtlb_req_d, dtlb_req_q;
 
-  assign itlb_req_o = itlb_req_q;
+// replacement strategy
+logic [SHARED_TLB_WAYS-1:0]          way_valid;
+logic                                update_lfsr;       // shift the LFSR
+logic [$clog2(SHARED_TLB_WAYS)-1:0]  inv_way;           // first non-valid encountered
+logic [$clog2(SHARED_TLB_WAYS)-1:0]  rnd_way;           // random index for replacement
+logic [$clog2(SHARED_TLB_WAYS)-1:0]  repl_way;          // way to replace
+logic [SHARED_TLB_WAYS-1:0]          repl_way_oh_d;     // way to replace (onehot)
+logic                                all_ways_valid;    // we need to switch repl strategy since all are valid
 
-  ///////////////////////////////////////////////////////
-  // tag comparison, hit generation
-  ///////////////////////////////////////////////////////
-  always_comb begin : itlb_dtlb_miss
-    itlb_miss_o         = 1'b0;
-    dtlb_miss_o         = 1'b0;
-    vpn0_d              = vpn0_q;
-    vpn1_d              = vpn1_q;
+logic asid_to_be_flushed_is0;   // indicates that the ASID provided by SFENCE.VMA (rs2)is 0, active high
+logic vaddr_to_be_flushed_is0;  // indicates that the VADDR provided by SFENCE.VMA (rs1)is 0, active high
+logic [SHARED_TLB_WAYS-1:0] vaddr_vpn0_match;
+logic [SHARED_TLB_WAYS-1:0] vaddr_vpn1_match;
 
-    tag_rd_en           = '0;
-    pte_rd_en           = '0;
+assign asid_to_be_flushed_is0 =  ~(|asid_to_be_flushed_i);
+assign vaddr_to_be_flushed_is0 = ~(|vaddr_to_be_flushed_i);
 
-    itlb_req_d          = 1'b0;
-    dtlb_req_d          = 1'b0;
+assign shared_tlb_access_o = shared_tlb_access_q;
+assign shared_tlb_hit_o = shared_tlb_hit_d;
+assign shared_tlb_vaddr_o = shared_tlb_vaddr_q;
 
-    tlb_update_asid_d   = tlb_update_asid_q;
+assign itlb_req_o = itlb_req_q;
 
-    shared_tlb_access_d = '0;
-    shared_tlb_vaddr_d  = shared_tlb_vaddr_q;
+///////////////////////////////////////////////////////
+// tag comparison, hit generation
+///////////////////////////////////////////////////////
+always_comb begin : itlb_dtlb_miss
+    itlb_miss_o     = 1'b0;
+    dtlb_miss_o     = 1'b0;
+    vpn0_d          = vpn0_q;
+    vpn1_d          = vpn1_q;
 
-    tag_rd_addr         = '0;
-    pte_rd_addr         = '0;
+    tag_rd_en       = '0;
+    pte_rd_en       = '0;
 
-    // if we got an ITLB miss
-    if (enable_translation_i & itlb_access_i & ~itlb_hit_i & ~dtlb_access_i) begin
-      tag_rd_en           = '1;
-      tag_rd_addr         = itlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
-      pte_rd_en           = '1;
-      pte_rd_addr         = itlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
+    itlb_req_d      = 1'b0;
+    dtlb_req_d      = 1'b0;
 
-      vpn0_d              = itlb_vaddr_i[21:12];
-      vpn1_d              = itlb_vaddr_i[31:22];
+    tlb_update_asid_d    = tlb_update_asid_q;
 
-      itlb_miss_o         = 1'b1;
-      itlb_req_d          = 1'b1;
+    shared_tlb_access_d  = '0;
+    shared_tlb_vaddr_d   = shared_tlb_vaddr_q;
 
-      tlb_update_asid_d   = asid_i;
+    tag_rd_addr    = '0;
+    pte_rd_addr    = '0;
 
-      shared_tlb_access_d = 1'b1;
-      shared_tlb_vaddr_d  = itlb_vaddr_i;
+    if (flush_i) begin
+        tag_rd_en        = '1;
+        pte_rd_en        = '1;
 
-      // we got an DTLB miss
-    end else if (en_ld_st_translation_i & dtlb_access_i & ~dtlb_hit_i) begin
-      tag_rd_en           = '1;
-      tag_rd_addr         = dtlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
-      pte_rd_en           = '1;
-      pte_rd_addr         = dtlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
+        vpn0_d           = vaddr_to_be_flushed_i[21:12];
+        vpn1_d           = vaddr_to_be_flushed_i[31:22];
 
-      vpn0_d              = dtlb_vaddr_i[21:12];
-      vpn1_d              = dtlb_vaddr_i[31:22];
+        tlb_update_asid_d   = asid_to_be_flushed_i;
 
-      dtlb_miss_o         = 1'b1;
-      dtlb_req_d          = 1'b1;
+        shared_tlb_access_d = 1'b1;
+        shared_tlb_vaddr_d  = vaddr_to_be_flushed_i;
 
-      tlb_update_asid_d   = asid_i;
+        tag_rd_addr      = vaddr_to_be_flushed_i[12+:$clog2(SHARED_TLB_DEPTH)];
+        pte_rd_addr      = vaddr_to_be_flushed_i[12+:$clog2(SHARED_TLB_DEPTH)];
+        
+    // No flush signal (not SFENCE.VMA ), contnue address translation
+    end else begin
+        // if we got an ITLB miss
+        if (enable_translation_i & itlb_access_i & ~itlb_hit_i & ~dtlb_access_i) begin
+            tag_rd_en        = '1;
+            tag_rd_addr      = itlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
+            pte_rd_en        = '1;
+            pte_rd_addr      = itlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
 
-      shared_tlb_access_d = 1'b1;
-      shared_tlb_vaddr_d  = dtlb_vaddr_i;
+            vpn0_d           = itlb_vaddr_i[21:12];
+            vpn1_d           = itlb_vaddr_i[31:22];
+
+            itlb_miss_o      = 1'b1;
+            itlb_req_d       = 1'b1;
+
+            tlb_update_asid_d   = asid_i;
+
+            shared_tlb_access_d = 1'b1;
+            shared_tlb_vaddr_d  = itlb_vaddr_i;
+
+        // we got an DTLB miss
+        end else if (en_ld_st_translation_i & dtlb_access_i & ~dtlb_hit_i) begin
+            tag_rd_en        = '1;
+            tag_rd_addr      = dtlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
+            pte_rd_en        = '1;
+            pte_rd_addr      = dtlb_vaddr_i[12+:$clog2(SHARED_TLB_DEPTH)];
+
+            vpn0_d           = dtlb_vaddr_i[21:12];
+            vpn1_d           = dtlb_vaddr_i[31:22];
+
+            dtlb_miss_o      = 1'b1;
+            dtlb_req_d       = 1'b1;
+
+            tlb_update_asid_d   = asid_i;
+
+            shared_tlb_access_d = 1'b1;
+            shared_tlb_vaddr_d  = dtlb_vaddr_i;
+        end
     end
-  end  //itlb_dtlb_miss
+end //itlb_dtlb_miss
 
-  always_comb begin : tag_comparison
+always_comb begin : tag_comparison
     shared_tlb_hit_d = 1'b0;
     dtlb_update_o = '0;
     itlb_update_o = '0;
     //number of ways
     for (int unsigned i = 0; i < SHARED_TLB_WAYS; i++) begin
-      if (shared_tag_valid[i] && ((tlb_update_asid_q == shared_tag_rd[i].asid) || pte[i].g)  && vpn1_q == shared_tag_rd[i].vpn1) begin
-        if (shared_tag_rd[i].is_4M || vpn0_q == shared_tag_rd[i].vpn0) begin
-          shared_tlb_hit_d = 1'b1;
-          if (itlb_req_q) begin
-            itlb_update_o.valid = 1'b1;
-            itlb_update_o.vpn = itlb_vpn_q;
-            itlb_update_o.is_4M = shared_tag_rd[i].is_4M;
-            itlb_update_o.asid = tlb_update_asid_q;
-            itlb_update_o.content = pte[i];
-          end else if (dtlb_req_q) begin
-            dtlb_update_o.valid = 1'b1;
-            dtlb_update_o.vpn = dtlb_vpn_q;
-            dtlb_update_o.is_4M = shared_tag_rd[i].is_4M;
-            dtlb_update_o.asid = tlb_update_asid_q;
-            dtlb_update_o.content = pte[i];
-          end
+        if (shared_tag_valid[i] && ((tlb_update_asid_q == shared_asid[i]) || pte[i].g)  && vpn1_q == shared_tag_rd[i].vpn1) begin
+            if (shared_tag_rd[i].is_4M || vpn0_q == shared_tag_rd[i].vpn0) begin
+                shared_tlb_hit_d    = 1'b1;
+                if (itlb_req_q) begin
+                    itlb_update_o.valid = 1'b1;
+                    itlb_update_o.vpn = itlb_vpn_q;
+                    itlb_update_o.is_4M = shared_tag_rd[i].is_4M;
+                    itlb_update_o.asid = tlb_update_asid_q;
+                    itlb_update_o.content = pte[i];
+                end else if (dtlb_req_q) begin
+                    dtlb_update_o.valid = 1'b1;
+                    dtlb_update_o.vpn = dtlb_vpn_q;
+                    dtlb_update_o.is_4M = shared_tag_rd[i].is_4M;
+                    dtlb_update_o.asid = tlb_update_asid_q;
+                    dtlb_update_o.content = pte[i];
+                end
+            end
         end
-      end
     end
-  end  //tag_comparison
+end //tag_comparison
 
-  // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      itlb_vpn_q <= '0;
-      dtlb_vpn_q <= '0;
-      tlb_update_asid_q <= '0;
-      shared_tlb_access_q <= '0;
-      shared_tlb_vaddr_q <= '0;
-      shared_tag_valid_q <= '0;
-      vpn0_q <= '0;
-      vpn1_q <= '0;
-      itlb_req_q <= '0;
-      dtlb_req_q <= '0;
-      shared_tag_valid <= '0;
-    end else begin
-      itlb_vpn_q <= itlb_vaddr_i[riscv::SV-1:12];
-      dtlb_vpn_q <= dtlb_vaddr_i[riscv::SV-1:12];
-      tlb_update_asid_q <= tlb_update_asid_d;
-      shared_tlb_access_q <= shared_tlb_access_d;
-      shared_tlb_vaddr_q <= shared_tlb_vaddr_d;
-      shared_tag_valid_q <= shared_tag_valid_d;
-      vpn0_q <= vpn0_d;
-      vpn1_q <= vpn1_d;
-      itlb_req_q <= itlb_req_d;
-      dtlb_req_q <= dtlb_req_d;
-      shared_tag_valid <= shared_tag_valid_q[tag_rd_addr];
-    end
+// sequential process
+always_ff @(posedge clk_i or negedge rst_ni) begin
+  if (~rst_ni) begin
+    itlb_vpn_q   <= '0;
+    dtlb_vpn_q   <= '0;
+    tlb_update_asid_q  <= '0;
+    shared_tlb_access_q <= '0;
+    shared_tlb_vaddr_q <= '0;
+    shared_tag_valid_q <= '0;
+    vpn0_q <= '0;
+    vpn1_q <= '0;
+    itlb_req_q <= '0;
+    dtlb_req_q <= '0;
+    shared_tag_valid <= '0;
+    shared_asid_q    <= '0;
+    shared_asid      <= '0;
+  end else begin
+    itlb_vpn_q   <= itlb_vaddr_i[riscv::SV-1:12];
+    dtlb_vpn_q   <= dtlb_vaddr_i[riscv::SV-1:12];
+    tlb_update_asid_q  <= tlb_update_asid_d;
+    shared_tlb_access_q <= shared_tlb_access_d;
+    shared_tlb_vaddr_q <= shared_tlb_vaddr_d;
+    shared_tag_valid_q <= shared_tag_valid_d;
+    vpn0_q <= vpn0_d;
+    vpn1_q <= vpn1_d;
+    itlb_req_q <= itlb_req_d;
+    dtlb_req_q <= dtlb_req_d;
+    shared_tag_valid <= shared_tag_valid_q[tag_rd_addr];
+    shared_asid_q <= shared_asid_d;
+    shared_asid   <= shared_asid_q[tag_rd_addr];
   end
+end
 
-  // ------------------
-  // Update and Flush
-  // ------------------
-  always_comb begin : update_flush
+// ------------------
+// Update and Flush
+// ------------------
+always_comb begin : update_flush
     shared_tag_valid_d = shared_tag_valid_q;
+    shared_asid_d = shared_asid_q;
     tag_wr_en = '0;
     pte_wr_en = '0;
 
-    if (flush_i) begin
-      shared_tag_valid_d = '0;
-    end else if (shared_tlb_update_i.valid) begin
-      for (int unsigned i = 0; i < SHARED_TLB_WAYS; i++) begin
-        if (repl_way_oh_d[i]) begin
-          shared_tag_valid_d[shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0]][i] = 1'b1;
-          tag_wr_en[i] = 1'b1;
-          pte_wr_en[i] = 1'b1;
+    for (int unsigned i = 0; i < SHARED_TLB_WAYS; i++) begin
+
+        vaddr_vpn0_match[i] = (vaddr_to_be_flushed_i[21:12] == shared_tag_rd[i].vpn0);
+        vaddr_vpn1_match[i] = (vaddr_to_be_flushed_i[31:22] == shared_tag_rd[i].vpn1);
+
+        if (flush_i) begin
+            // flush everything if ASID is 0 and vaddr is 0 ("SFENCE.VMA x0 x0" case)
+            if (asid_to_be_flushed_is0 && vaddr_to_be_flushed_is0 )
+                shared_tag_valid_d = '0;
+            // flush vaddr in all addressing space ("SFENCE.VMA vaddr x0" case), it should happen only for leaf pages
+            else if (asid_to_be_flushed_is0 && ( (vaddr_vpn0_match[i] && vaddr_vpn1_match[i]) || (vaddr_vpn1_match[i] && shared_tag_rd[i].is_4M) ) && (~vaddr_to_be_flushed_is0))
+                shared_tag_valid_d[tag_rd_addr][i] = '0;
+            // the entry is flushed if it's not global and asid and vaddr both matches with the entry to be flushed ("SFENCE.VMA vaddr asid" case)
+            else if ( (!pte[i].g) && ((vaddr_vpn0_match[i] && vaddr_vpn1_match[i]) || (vaddr_vpn1_match[i] && shared_tag_rd[i].is_4M)) && (asid_to_be_flushed_i == shared_asid[i]) && (!vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0) )
+                shared_tag_valid_d[tag_rd_addr][i] = '0;
+            // the entry is flushed if it's not global, and the asid matches and vaddr is 0. ("SFENCE.VMA 0 asid" case)
+            else if ( (!pte[i].g) && (vaddr_to_be_flushed_is0) && (!asid_to_be_flushed_is0) ) begin
+                for (int unsigned k = 0; k < SHARED_TLB_DEPTH; ++k) begin
+                    if (asid_to_be_flushed_i == shared_asid_q[k][i])
+                        shared_tag_valid_d[k][i] = '0;
+                end
+            end
+
+        end else if (shared_tlb_update_i.valid) begin 
+            if (repl_way_oh_d[i]) begin
+                shared_tag_valid_d[shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0]][i] = 1'b1;
+                shared_asid_d[shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0]][i] = shared_tlb_update_i.asid[ASID_WIDTH-1:0];
+                tag_wr_en[i] = 1'b1;
+                pte_wr_en[i] = 1'b1;
+            end
         end
-      end
     end
-  end  //update_flush
+end //update_flush
 
-  assign shared_tag_wr.asid = shared_tlb_update_i.asid;
-  assign shared_tag_wr.vpn1 = shared_tlb_update_i.vpn[19:10];
-  assign shared_tag_wr.vpn0 = shared_tlb_update_i.vpn[9:0];
-  assign shared_tag_wr.is_4M = shared_tlb_update_i.is_4M;
+assign shared_tag_wr.vpn1  = shared_tlb_update_i.vpn[19:10];
+assign shared_tag_wr.vpn0  = shared_tlb_update_i.vpn[9:0];
+assign shared_tag_wr.is_4M = shared_tlb_update_i.is_4M;
 
-  assign tag_wr_addr = shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0];
-  assign tag_wr_data = shared_tag_wr;
+assign tag_wr_addr = shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0];
+assign tag_wr_data = shared_tag_wr;
 
-  assign pte_wr_addr = shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0];
-  assign pte_wr_data = shared_tlb_update_i.content;
+assign pte_wr_addr = shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0];
+assign pte_wr_data = shared_tlb_update_i.content;
 
-  assign way_valid = shared_tag_valid_q[shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0]];
-  assign repl_way = (all_ways_valid) ? rnd_way : inv_way;
-  assign update_lfsr = shared_tlb_update_i.valid & all_ways_valid;
-  assign repl_way_oh_d = (shared_tlb_update_i.valid) ? shared_tlb_way_bin2oh(repl_way) : '0;
+assign way_valid     = shared_tag_valid_q[shared_tlb_update_i.vpn[$clog2(SHARED_TLB_DEPTH)-1:0]];
+assign repl_way      = (all_ways_valid) ? rnd_way : inv_way;
+assign update_lfsr   = shared_tlb_update_i.valid & all_ways_valid;
+assign repl_way_oh_d = (shared_tlb_update_i.valid) ? shared_tlb_way_bin2oh(repl_way) : '0;
 
-  lzc #(
-      .WIDTH(SHARED_TLB_WAYS)
-  ) i_lzc (
-      .in_i   (~way_valid),
-      .cnt_o  (inv_way),
-      .empty_o(all_ways_valid)
-  );
+lzc #(
+    .WIDTH ( SHARED_TLB_WAYS )
+) i_lzc (
+    .in_i    ( ~way_valid     ),
+    .cnt_o   ( inv_way        ),
+    .empty_o ( all_ways_valid )
+);
 
-  lfsr #(
-      .LfsrWidth(8),
-      .OutWidth ($clog2(SHARED_TLB_WAYS))
-  ) i_lfsr (
-      .clk_i (clk_i),
-      .rst_ni(rst_ni),
-      .en_i  (update_lfsr),
-      .out_o (rnd_way)
-  );
+lfsr #(
+    .LfsrWidth  ( 8       ),
+    .OutWidth   ( $clog2(SHARED_TLB_WAYS))
+) i_lfsr (
+    .clk_i          ( clk_i       ),
+    .rst_ni         ( rst_ni      ),
+    .en_i           ( update_lfsr ),
+    .out_o          ( rnd_way     )
+);
 
-  ///////////////////////////////////////////////////////
-  // memory arrays and regs
-  ///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////
+// memory arrays and regs
+///////////////////////////////////////////////////////
 
-  assign tag_req  = tag_wr_en | tag_rd_en;
-  assign tag_we   = tag_wr_en;
-  assign tag_addr = tag_wr_en ? tag_wr_addr : tag_rd_addr;
+assign tag_req = tag_wr_en | tag_rd_en;
+assign tag_we = tag_wr_en;
+assign tag_addr = tag_wr_en ? tag_wr_addr : tag_rd_addr;
 
-  assign pte_req  = pte_wr_en | pte_rd_en;
-  assign pte_we   = pte_wr_en;
-  assign pte_addr = pte_wr_en ? pte_wr_addr : pte_rd_addr;
+assign pte_req = pte_wr_en | pte_rd_en;
+assign pte_we = pte_wr_en;
+assign pte_addr = pte_wr_en ? pte_wr_addr : pte_rd_addr;
 
-  for (genvar i = 0; i < SHARED_TLB_WAYS; i++) begin : gen_sram
+for (genvar i = 0; i < SHARED_TLB_WAYS; i++) begin : gen_sram
     // Tag RAM
     sram #(
-        .DATA_WIDTH($bits(shared_tag_t)),
-        .NUM_WORDS (SHARED_TLB_DEPTH)
+        .DATA_WIDTH ( $bits(shared_tag_t) ),
+        .NUM_WORDS  ( SHARED_TLB_DEPTH   )
     ) tag_sram (
-        .clk_i  (clk_i),
-        .rst_ni (rst_ni),
-        .req_i  (tag_req[i]),
-        .we_i   (tag_we[i]),
-        .addr_i (tag_addr),
-        .wuser_i('0),
-        .wdata_i(tag_wr_data),
-        .be_i   ('1),
-        .ruser_o(),
-        .rdata_o(tag_rd_data[i])
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .req_i      ( tag_req[i]      ),
+        .we_i       ( tag_we[i]       ),
+        .addr_i     ( tag_addr        ),
+        .wuser_i    ( '0              ),
+        .wdata_i    ( tag_wr_data     ),
+        .be_i       ( '1              ),
+        .ruser_o    (                 ),
+        .rdata_o    ( tag_rd_data[i]  )
     );
 
     assign shared_tag_rd[i] = shared_tag_t'(tag_rd_data[i]);
 
     // PTE RAM
     sram #(
-        .DATA_WIDTH($bits(riscv::pte_sv32_t)),
-        .NUM_WORDS (SHARED_TLB_DEPTH)
+        .DATA_WIDTH ( $bits(riscv::pte_sv32_t) ),
+        .NUM_WORDS  ( SHARED_TLB_DEPTH   )
     ) pte_sram (
-        .clk_i  (clk_i),
-        .rst_ni (rst_ni),
-        .req_i  (pte_req[i]),
-        .we_i   (pte_we[i]),
-        .addr_i (pte_addr),
-        .wuser_i('0),
-        .wdata_i(pte_wr_data),
-        .be_i   ('1),
-        .ruser_o(),
-        .rdata_o(pte_rd_data[i])
+        .clk_i      ( clk_i           ),
+        .rst_ni     ( rst_ni          ),
+        .req_i      ( pte_req[i]      ),
+        .we_i       ( pte_we[i]       ),
+        .addr_i     ( pte_addr        ),
+        .wuser_i    ( '0              ),
+        .wdata_i    ( pte_wr_data     ),
+        .be_i       ( '1              ),
+        .ruser_o    (                 ),
+        .rdata_o    ( pte_rd_data[i]  )
     );
     assign pte[i] = riscv::pte_sv32_t'(pte_rd_data[i]);
-  end
+end
 endmodule
 
 /* verilator lint_on WIDTH */


### PR DESCRIPTION
This PR adds SFENCE.VMA instruction cases in Shared translation look aside buffer (TLB) in CVA6 Memory Management Unit (MMU) of SV32.

**Problem**
when ever flush signal is asserted due to SFENCE.VMA instruction, whole TLB is invalidated without looking for its cases, which make unnecessary invalidation of page table entries (PTE) which are not supposed to be invalidated.

**Cases**
1. SFENCE.VMA x0 x0
    This is special case which invalidates whole TLB entries.
3. SFENCE.VMA vaddr x0
    For this case PTE read address is set to lower six bits of vaddr. After necessary comparisons particular PTE present at vaddr is invalidated.
5. SFENCE.VMA vaddr asid
    In this case same logic is used, PTE read address is set to lower six bits of vaddr. After necessary comparisons particular PTE present at vaddr is invalidated.
7. SFENCE.VMA 0 asid
    This is special case which need traversal of whole TLB, because in this perticular case vaddr to be flushed is zero and asid to be flushed is not. So we need to traverse whole TLB and check for the perticular AISD in PTE.