### PR TITLE
SFENCE.VMA cases for MMU_SV32 Shared TLB

### DIFF
--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -169,7 +169,10 @@ module cva6_mmu_sv32
       .enable_translation_i  (enable_translation_i),
       .en_ld_st_translation_i(en_ld_st_translation_i),
 
-      .asid_i       (asid_i),
+      .asid_i                (asid_i),
+      .asid_to_be_flushed_i  (asid_to_be_flushed_i),
+      .vaddr_to_be_flushed_i (vaddr_to_be_flushed_i),
+
       // from TLBs
       // did we miss?
       .itlb_access_i(itlb_lu_access),


### PR DESCRIPTION
This PR adds SFENCE.VMA instruction cases in Shared translation look aside buffer (TLB) in CVA6 Memory Management Unit (MMU) of SV32.

**Problem**
when ever flush signal is asserted due to SFENCE.VMA instruction, whole TLB is invalidated without looking for its cases, which make unnecessary invalidation of page table entries (PTE) which are not supposed to be invalidated.

**Cases**

1. SFENCE.VMA x0 x0
    This is special case which invalidates whole TLB entries.
2. SFENCE.VMA vaddr x0
     For this case PTE read address is set to lower six bits of vaddr. After necessary comparisons particular PTE present at vaddr is 
     invalidated.
3. SFENCE.VMA vaddr asid
    In this case same logic is used, PTE read address is set to lower six bits of vaddr (VPN0). After necessary comparisons 
    particular PTE present at vaddr is invalidated.
4. SFENCE.VMA 0 asid
    In this perticular case vaddr to be flushed is zero and asid to be flushed is not. So we can not retrieve required PTE and check 
    for the perticular AISD in PTE.

**Solution**
Introducing an array to store ASID out of SRAM which helps us handle all the cases efficiently. Based on the read address the required two way ASID is can be retrieved and subjected into checks for invalidation (flushing).
