### PR TITLE
CVA6 config file for comparison

### DIFF
--- a/core/include/cv32a6_ima_comp_config_pkg.sv
+++ b/core/include/cv32a6_ima_comp_config_pkg.sv
@@ -1,0 +1,146 @@
+// Copyright 2022 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+
+package cva6_config_pkg;
+
+  localparam CVA6ConfigXlen = 32;
+
+  localparam CVA6ConfigFpuEn = 0;
+  localparam CVA6ConfigF16En = 0;
+  localparam CVA6ConfigF16AltEn = 0;
+  localparam CVA6ConfigF8En = 0;
+  localparam CVA6ConfigFVecEn = 0;
+
+  localparam CVA6ConfigCvxifEn = 0;
+  localparam CVA6ConfigCExtEn = 0;
+  localparam CVA6ConfigZcbExtEn = 0;
+  localparam CVA6ConfigAExtEn = 1;
+  localparam CVA6ConfigBExtEn = 0;
+  localparam CVA6ConfigVExtEn = 0;
+  localparam CVA6ConfigZiCondExtEn = 0;
+
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 64;
+  localparam CVA6ConfigAxiDataWidth = 64;
+  localparam CVA6ConfigFetchUserEn = 0;
+  localparam CVA6ConfigFetchUserWidth = CVA6ConfigXlen;
+  localparam CVA6ConfigDataUserEn = 0;
+  localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen;
+
+  localparam CVA6ConfigIcacheByteSize = 16384;
+  localparam CVA6ConfigIcacheSetAssoc = 1;
+  localparam CVA6ConfigIcacheLineWidth = 128;
+  localparam CVA6ConfigDcacheByteSize = 65536;
+  localparam CVA6ConfigDcacheSetAssoc = 1;
+  localparam CVA6ConfigDcacheLineWidth = 128;
+
+  localparam CVA6ConfigDcacheIdWidth = 1;
+  localparam CVA6ConfigMemTidWidth = 2;
+
+  localparam CVA6ConfigWtDcacheWbufDepth = 8;
+
+  localparam CVA6ConfigNrCommitPorts = 1;
+  localparam CVA6ConfigNrScoreboardEntries = 4;
+
+  localparam CVA6ConfigFPGAEn = 0;
+
+  localparam CVA6ConfigNrLoadPipeRegs = 1;
+  localparam CVA6ConfigNrStorePipeRegs = 0;
+  localparam CVA6ConfigNrLoadBufEntries = 2;
+
+  localparam CVA6ConfigInstrTlbEntries = 16;
+  localparam CVA6ConfigDataTlbEntries = 8;
+
+  localparam CVA6ConfigRASDepth = 0;
+  localparam CVA6ConfigBTBEntries = 0;
+  localparam CVA6ConfigBHTEntries = 0;
+
+  localparam CVA6ConfigNrPMPEntries = 8;
+
+  localparam CVA6ConfigPerfCounterEn = 0;
+
+  localparam config_pkg::cache_type_t CVA6ConfigDcacheType = config_pkg::WT;
+
+  localparam CVA6ConfigMmuPresent = 1;
+
+  localparam CVA6ConfigRvfiTrace = 1;
+
+  localparam config_pkg::cva6_cfg_t cva6_cfg = '{
+      NrCommitPorts: unsigned'(CVA6ConfigNrCommitPorts),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      NrLoadBufEntries: unsigned'(CVA6ConfigNrLoadBufEntries),
+      FpuEn: bit'(CVA6ConfigFpuEn),
+      XF16: bit'(CVA6ConfigF16En),
+      XF16ALT: bit'(CVA6ConfigF16AltEn),
+      XF8: bit'(CVA6ConfigF8En),
+      RVA: bit'(CVA6ConfigAExtEn),
+      RVV: bit'(CVA6ConfigVExtEn),
+      RVC: bit'(CVA6ConfigCExtEn),
+      RVZCB: bit'(CVA6ConfigZcbExtEn),
+      XFVec: bit'(CVA6ConfigFVecEn),
+      CvxifEn: bit'(CVA6ConfigCvxifEn),
+      ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      // Extended
+      RVF:
+      bit'(
+      0
+      ),
+      RVD: bit'(0),
+      FpPresent: bit'(0),
+      NSX: bit'(0),
+      FLen: unsigned'(0),
+      RVFVec: bit'(0),
+      XF16Vec: bit'(0),
+      XF16ALTVec: bit'(0),
+      XF8Vec: bit'(0),
+      NrRgprPorts: unsigned'(0),
+      NrWbPorts: unsigned'(0),
+      EnableAccelerator: bit'(0),
+      RVS: bit'(1),
+      RVU: bit'(1),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(CVA6ConfigRASDepth),
+      BTBEntries: unsigned'(CVA6ConfigBTBEntries),
+      BHTEntries: unsigned'(CVA6ConfigBHTEntries),
+      DmBaseAddress: 64'h0,
+      NrPMPEntries: unsigned'(CVA6ConfigNrPMPEntries),
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      // idempotent region
+      NrNonIdempotentRules:
+      unsigned'(
+      2
+      ),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength: 1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules: unsigned'(3),
+      //                      DRAM,          Boot ROM,   Debug Module
+      ExecuteRegionAddrBase:
+      1024'(
+      {64'h8000_0000, 64'h1_0000, 64'h0}
+      ),
+      ExecuteRegionLength: 1024'({64'h40000000, 64'h10000, 64'h1000}),
+      // cached region
+      NrCachedRegionRules:
+      unsigned'(
+      1
+      ),
+      CachedRegionAddrBase: 1024'({64'h8000_0000}),
+      CachedRegionLength: 1024'({64'h40000000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1),
+      NonIdemPotenceEn: bit'(0),
+      AxiBurstWriteEn: bit'(0)
+  };
+
+endpackage

--- a/core/include/cv32a6_ima_comp_config_pkg.sv
+++ b/core/include/cv32a6_ima_comp_config_pkg.sv
@@ -35,9 +35,9 @@ package cva6_config_pkg;
   localparam CVA6ConfigDataUserWidth = CVA6ConfigXlen;
 
   localparam CVA6ConfigIcacheByteSize = 16384;
-  localparam CVA6ConfigIcacheSetAssoc = 1;
+  localparam CVA6ConfigIcacheSetAssoc = 2;
   localparam CVA6ConfigIcacheLineWidth = 128;
-  localparam CVA6ConfigDcacheByteSize = 65536;
+  localparam CVA6ConfigDcacheByteSize = 16384;
   localparam CVA6ConfigDcacheSetAssoc = 1;
   localparam CVA6ConfigDcacheLineWidth = 128;
 


### PR DESCRIPTION
This configuration file can be used to dilute CVA6 for performance comparison purposes