### PR TITLE
Add the condition for updating the tlb only after a miss is incurred

### DIFF
--- a/core/mmu_sv32/cva6_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_tlb_sv32.sv
@@ -124,7 +124,7 @@ module cva6_tlb_sv32
         else if ((!content_q[i].g) && (vaddr_to_be_flushed_is0) && (asid_to_be_flushed_i == tags_q[i].asid[ASID_WIDTH-1:0]) && (!asid_to_be_flushed_is0))
           tags_n[i].valid = 1'b0;
         // normal replacement
-      end else if (update_i.valid & replace_en[i]) begin
+      end else if (update_i.valid & replace_en[i] && !lu_hit_o) begin
         // update tag array
         tags_n[i] = '{
             asid: update_i.asid,


### PR DESCRIPTION
**Problem Statement:**

In the TLB module of the MMU_sv32 unit during the update and flush mode, if the flush signal is high, the TLB is flushed according to the SFENCE.VMA command. However, in the event that the flush signal is not enabled the value in the TLB module is updated regardless of whether there was a hit or a miss in the TLB. If the updated value from the shared TLB is valid one of the entries in the TLB is updated with this value.

**Proposed Solution:**

During the update phase while checking that the updated value is valid or not it should also be checked that the TLB was missed and only in the case that the TLB was missed should the SHARED_TLB be accessed and an update value received from it.